### PR TITLE
Support optional references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # optional
-Single header implementation of `std::optional` with functional-style extensions.
+Single header implementation of `std::optional` with functional-style extensions and support for references.
 
 Clang + GCC: [![Linux Build Status](https://travis-ci.org/TartanLlama/optional.png?branch=master)](https://travis-ci.org/TartanLlama/optional)
 MSVC: [![Windows Build Status](https://ci.appveyor.com/api/projects/status/k5x00xa11y3s5wsg?svg=true)](https://ci.appveyor.com/project/TartanLlama/optional)
@@ -65,6 +65,26 @@ The interface is the same as `std::optional`, but the following member functions
   * `tl::optional<int>{}.disjunction(13); //13`
 - `take`: returns the current value, leaving the optional empty.
   * `opt_string.take().map(&std::string::size); //opt_string now empty;`
+
+In addition to those member functions, optional references are also supported:
+
+```
+int i = 42;
+tl::optional<int&> o = i;
+*o == 42; //true
+i = 12;
+*o = 12; //true
+&*o == &i; //true
+```
+
+Assignment has rebind semantics rather than assign-through semantics:
+
+```
+int j = 8;
+o = j;
+
+&*o == &j; //true
+```
 
 ### Compiler support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,16 +99,24 @@ namespace <a href='doc_optional.html#optional.hpp'>tl</a>
     constexpr bool <a href='doc_optional.html#tl::operator==(constoptional-T-&,constU&)'>operator&gt;=</a>(const U&amp; lhs, const <a href='doc_optional.html#tl::optional-T-'>optional&lt;T&gt;</a>&amp; rhs);
     
     template &lt;class T&gt;
-    void swap(optional&lt;T&gt; &amp;lhs, optional&lt;T&gt;
+    void swap(optional&lt;T&gt; &amp;lhs, optional&lt;T&gt; &amp;rhs);
     
-    template &lt;class T&gt;
-    constexpr <a href='doc_optional.html#tl::optional-T-'>optional&lt;detail::decay_t&lt;T&gt;&gt;</a> <a href='doc_optional.html#optional.hpp'>make_optional</a>(T&amp;&amp; v);
+    namespace <a href='doc_optional.html#optional.hpp'>detail</a>
+    {
+        struct <a href='doc_optional.html#optional.hpp'>i_am_secret</a>;
+    }
+    
+    template &lt;class T = detail::i_am_secret, class U, class Ret = detail::conditional_t&lt;std::is_same&lt;T, detail::i_am_secret&gt;::value, detail::decay_t&lt;U&gt;, T&gt;&gt;
+    constexpr <a href='doc_optional.html#tl::optional-T-'>optional&lt;Ret&gt;</a> <a href='doc_optional.html#optional.hpp'>make_optional</a>(U&amp;&amp; v);
     
     template &lt;class T, class ... Args&gt;
     constexpr <a href='doc_optional.html#tl::optional-T-'>optional&lt;T&gt;</a> <a href='doc_optional.html#optional.hpp'>make_optional</a>(Args&amp;&amp;... args);
     
     template &lt;class T, class U, class ... Args&gt;
     constexpr <a href='doc_optional.html#tl::optional-T-'>optional&lt;T&gt;</a> <a href='doc_optional.html#optional.hpp'>make_optional</a>(<a href='http://en.cppreference.com/mwiki/index.php?title=Special%3ASearch&search=std::initializer_list%3cU%3e'>std::initializer_list&lt;U&gt;</a> il, Args&amp;&amp;... args);
+    
+    template &lt;class T&gt;
+    class <a href='doc_optional.html#tl::optional-T&-'>optional&lt;T&amp;&gt;</a>;
 }
 
 namespace <a href='doc_optional.html#optional.hpp'>std</a>
@@ -229,9 +237,9 @@ public:
     
     constexpr <a href='doc_optional.html#tl::optional-T-::optional(optional-T-&&)'>optional</a>(<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp;&amp; rhs) = default;
     
-    template &lt;class... Args&gt; constexpr explicit
+    template &lt;class... Args&gt; constexpr explicit optional(in_place_t, Args&amp;&amp;... args);
     template &lt;class U, class... Args&gt;
-    constexpr explicit
+    constexpr explicit optional(in_place_t, std::initializer_list&lt;U&gt;&amp;, Args&amp;&amp;... args);
     
     template &lt;class U=T&gt; constexpr optional(U &amp;&amp;u);
     
@@ -255,9 +263,8 @@ public:
     
     template &lt;class ... Args&gt;
     T&amp; <a href='doc_optional.html#tl::optional-T-::emplace(Args&&...)'>emplace</a>(Args&amp;&amp;... args);
-    
     template &lt;class U, class... Args&gt;
-    T&amp;
+    T&amp; emplace(std::initializer_list&lt;U&gt; il, Args &amp;&amp;... args);
     
     void <a href='doc_optional.html#tl::optional-T-::swap(optional-T-&)'>swap</a>(<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) noexcept(std::is_nothrow_move_constructible&lt;T&gt;::value&amp;&amp;detail::is_nothrow_swappable&lt;T&gt;::value);
     
@@ -270,7 +277,7 @@ public:
     constexpr bool <a href='doc_optional.html#tl::optional-T-::has_value()const'>has_value</a>() const noexcept;
     constexpr <a href='doc_optional.html#tl::optional-T-::has_value()const'>operator bool</a>() const noexcept;
     
-    constexpr T&amp; <a href='doc_optional.html#tl::optional-T-::value()&'>value</a>() &amp;;
+    constexpr T &amp;value();
     constexpr const T &amp;value() const;
     
     template &lt;class U&gt;
@@ -323,7 +330,9 @@ Carries out some operation on the stored object if there is one.
 
 Calls `f` if the optional is empty
 
-*Requires*: `std::invoke_result_t<F>` must be void or convertible to `optional<T>`. \\effects If `*this` has a value, returns `*this`. Otherwise, if `f` returns `void`, calls `std::forward<F>(f)` and returns `std::nullopt`. Otherwise, returns `std::forward<F>(f)()`.
+*Requires*: `std::invoke_result_t<F>` must be void or convertible to `optional<T>`.
+
+*Effects*: If `*this` has a value, returns `*this`. Otherwise, if `f` returns `void`, calls `std::forward<F>(f)` and returns `std::nullopt`. Otherwise, returns `std::forward<F>(f)()`.
 
 ### Function template `tl::optional::map_or`<a id="tl::optional-T-::map_or(F&&,U&&)&"></a>
 
@@ -408,7 +417,7 @@ Takes the value out of the optional, leaving it empty
 
 Constructs an optional that does not contain a value.
 
-### Constructor `tl::optional::optional`<a id="tl::optional-T-::optional(constoptional-T-&)"></a>
+### Copy constructor `tl::optional::optional`<a id="tl::optional-T-::optional(constoptional-T-&)"></a>
 
 <pre><code class="language-cpp">constexpr optional(const <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) = default;</code></pre>
 
@@ -416,7 +425,7 @@ Copy constructor
 
 If `rhs` contains a value, the stored value is direct-initialized with it. Otherwise, the constructed optional is empty.
 
-### Constructor `tl::optional::optional`<a id="tl::optional-T-::optional(optional-T-&&)"></a>
+### Move constructor `tl::optional::optional`<a id="tl::optional-T-::optional(optional-T-&&)"></a>
 
 <pre><code class="language-cpp">constexpr optional(<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp;&amp; rhs) = default;</code></pre>
 
@@ -426,14 +435,12 @@ If `rhs` contains a value, the stored value is direct-initialized with it. Other
 
 ### Function template `tl::optional::optional`<a id="tl::optional-T-::optional(detail::enable_if_t-std::is_constructible-T,Args...-::value,in_place_t-,Args&&...)"></a>
 
-<pre><code class="language-cpp">(1)  template &lt;class... Args&gt; constexpr explicit
+<pre><code class="language-cpp">(1)  template &lt;class... Args&gt; constexpr explicit optional(in_place_t, Args&amp;&amp;... args);
 
 (2)  template &lt;class U, class... Args&gt;
-     constexpr explicit</code></pre>
+     constexpr explicit optional(in_place_t, std::initializer_list&lt;U&gt;&amp;, Args&amp;&amp;... args);</code></pre>
 
 Constructs the stored value in-place using the given arguments.
-
-optional(in\_place\_t, Args&&... args);
 
 ### Function template `tl::optional::optional`<a id="tl::optional-T-::optional(U&&)"></a>
 
@@ -507,17 +514,13 @@ Moves the value from `rhs` if there is one. Otherwise resets the stored value in
 
 ### Function template `tl::optional::emplace`<a id="tl::optional-T-::emplace(Args&&...)"></a>
 
-<pre><code class="language-cpp">template &lt;class ... Args&gt;
-T&amp; emplace(Args&amp;&amp;... args);</code></pre>
+<pre><code class="language-cpp">(1)  template &lt;class ... Args&gt;
+     T&amp; emplace(Args&amp;&amp;... args);
 
-Constructs the value in-place, destroying the current one if there is one. \\group emplace
+(2)  template &lt;class U, class... Args&gt;
+     T&amp; emplace(std::initializer_list&lt;U&gt; il, Args &amp;&amp;... args);</code></pre>
 
-### Function template `tl::optional::emplace`<a id="tl::optional-T-::emplace(std::initializer_list-U-,Args&&...)"></a>
-
-<pre><code class="language-cpp">(1)  template &lt;class U, class... Args&gt;
-     T&amp;</code></pre>
-
-emplace(std::initializer\_list\<U\> il, Args &&... args);
+Constructs the value in-place, destroying the current one if there is one.
 
 ### Function `tl::optional::swap`<a id="tl::optional-T-::swap(optional-T-&)"></a>
 
@@ -557,13 +560,11 @@ If neither optionals have a value, nothing happens. If both have a value, the va
 
 ### Function `tl::optional::value`<a id="tl::optional-T-::value()&"></a>
 
-<pre><code class="language-cpp">(1)  constexpr T&amp; value() &amp;;
+<pre><code class="language-cpp">(1)  constexpr T &amp;value();
 
 (2)  constexpr const T &amp;value() const;</code></pre>
 
 *Returns*: the contained value if there is one, otherwise throws \[bad\_optional\_access\]
-
-synopsis constexpr T \&value();
 
 ### Function template `tl::optional::value_or`<a id="tl::optional-T-::value_or(U&&)const&"></a>
 
@@ -691,11 +692,385 @@ Compares the optional with a value.
 
 If the optional has a value, it is compared with the other value using `T`s relational operators. Otherwise, the optional is considered less than the value.
 
-## Function template `tl::swap`<a id="tl::swap(optional-T-&,optional-T-&)"></a>
+## Class template `tl::optional<T&>`<a id="tl::optional-T&-"></a>
 
 <pre><code class="language-cpp">template &lt;class T&gt;
-void swap(optional&lt;T&gt; &amp;lhs, optional&lt;T&gt;</code></pre>
+class optional&lt;T&amp;&gt;
+{
+public:
+    template &lt;class F&gt;
+    constexpr auto and_then(F &amp;&amp;f) &amp;;
+    template &lt;class F&gt;
+    constexpr auto and_then(F &amp;&amp;f) &amp;&amp;;
+    template &lt;class F&gt;
+    constexpr auto and_then(F &amp;&amp;f) const &amp;;
+    template &lt;class F&gt;
+    constexpr auto and_then(F &amp;&amp;f) const &amp;&amp;;
+    
+    template &lt;class F&gt; constexpr auto map(F &amp;&amp;f) &amp;;
+    template &lt;class F&gt; constexpr auto map(F &amp;&amp;f) &amp;&amp;;
+    template &lt;class F&gt; constexpr auto map(F &amp;&amp;f) const&amp;;
+    template &lt;class F&gt; constexpr auto map(F &amp;&amp;f) const&amp;&amp;;
+    
+    template &lt;class F&gt; optional&lt;T&gt; or_else (F &amp;&amp;f) &amp;;
+    template &lt;class F&gt; optional&lt;T&gt; or_else (F &amp;&amp;f) &amp;&amp;;
+    template &lt;class F&gt; optional&lt;T&gt; or_else (F &amp;&amp;f) const &amp;;
+    
+    template &lt;class F, class U&gt;
+    U <a href='doc_optional.html#tl::optional-T&-::map_or(F&&,U&&)&'>map_or</a>(F&amp;&amp; f, U&amp;&amp; u) &amp;;
+    template &lt;class F, class U&gt;
+    U <a href='doc_optional.html#tl::optional-T&-::map_or(F&&,U&&)&'>map_or</a>(F&amp;&amp; f, U&amp;&amp; u) &amp;&amp;;
+    template &lt;class F, class U&gt;
+    U <a href='doc_optional.html#tl::optional-T&-::map_or(F&&,U&&)&'>map_or</a>(F&amp;&amp; f, U&amp;&amp; u) const &amp;;
+    template &lt;class F, class U&gt;
+    U <a href='doc_optional.html#tl::optional-T&-::map_or(F&&,U&&)&'>map_or</a>(F&amp;&amp; f, U&amp;&amp; u) const &amp;&amp;;
+    
+    template &lt;class F, class U&gt;
+    auto map_or_else(F &amp;&amp;f, U &amp;&amp;u) &amp;;
+    template &lt;class F, class U&gt;
+    auto map_or_else(F &amp;&amp;f, U &amp;&amp;u)
+    template &lt;class F, class U&gt;
+    auto map_or_else(F &amp;&amp;f, U &amp;&amp;u)
+    template &lt;class F, class U&gt;
+    auto map_or_else(F &amp;&amp;f, U &amp;&amp;u)
+    
+    template &lt;class U&gt;
+    constexpr <a href='doc_optional.html#tl::optional-T-'>optional&lt;typename std::decay&lt;U&gt;::type&gt;</a> <a href='doc_optional.html#tl::optional-T&-::conjunction(U&&)const'>conjunction</a>(U&amp;&amp; u) const;
+    
+    constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> <a href='doc_optional.html#tl::optional-T&-::disjunction(constoptional&)&'>disjunction</a>(const <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) &amp;;
+    constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> <a href='doc_optional.html#tl::optional-T&-::disjunction(constoptional&)&'>disjunction</a>(const <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) const &amp;;
+    constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> <a href='doc_optional.html#tl::optional-T&-::disjunction(constoptional&)&'>disjunction</a>(const <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) &amp;&amp;;
+    constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> <a href='doc_optional.html#tl::optional-T&-::disjunction(constoptional&)&'>disjunction</a>(const <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) const &amp;&amp;;
+    constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> <a href='doc_optional.html#tl::optional-T&-::disjunction(constoptional&)&'>disjunction</a>(<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp;&amp; rhs) &amp;;
+    constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> <a href='doc_optional.html#tl::optional-T&-::disjunction(constoptional&)&'>disjunction</a>(<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp;&amp; rhs) const &amp;;
+    constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> <a href='doc_optional.html#tl::optional-T&-::disjunction(constoptional&)&'>disjunction</a>(<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp;&amp; rhs) &amp;&amp;;
+    constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> <a href='doc_optional.html#tl::optional-T&-::disjunction(constoptional&)&'>disjunction</a>(<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp;&amp; rhs) const &amp;&amp;;
+    
+    <a href='doc_optional.html#tl::optional-T-'>optional</a> <a href='doc_optional.html#tl::optional-T&-::take()&'>take</a>() &amp;;
+    <a href='doc_optional.html#tl::optional-T-'>optional</a> <a href='doc_optional.html#tl::optional-T&-::take()&'>take</a>() const &amp;;
+    <a href='doc_optional.html#tl::optional-T-'>optional</a> <a href='doc_optional.html#tl::optional-T&-::take()&'>take</a>() &amp;&amp;;
+    <a href='doc_optional.html#tl::optional-T-'>optional</a> <a href='doc_optional.html#tl::optional-T&-::take()&'>take</a>() const &amp;&amp;;
+    
+    using <a href='doc_optional.html#tl::optional-T&-'>value_type</a> = T&amp;;
+    
+    constexpr <a href='doc_optional.html#tl::optional-T&-::optional()'>optional</a>() noexcept;
+    constexpr <a href='doc_optional.html#tl::optional-T&-::optional()'>optional</a>(<a href='doc_optional.html#tl::nullopt_t'>nullopt_t</a>) noexcept;
+    
+    constexpr <a href='doc_optional.html#tl::optional-T&-::optional(constoptional&)'>optional</a>(const <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) noexcept = default;
+    
+    constexpr <a href='doc_optional.html#tl::optional-T&-::optional(optional&&)'>optional</a>(<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp;&amp; rhs) = default;
+    
+    template &lt;class U=T&gt; constexpr optional(U &amp;&amp;u);
+    
+    <a href='doc_optional.html#tl::optional-T&-::~optional()'>~optional</a>() = default;
+    
+    <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; <a href='doc_optional.html#tl::optional-T&-::operator=(tl::nullopt_t)'>operator=</a>(<a href='doc_optional.html#tl::nullopt_t'>nullopt_t</a>) noexcept;
+    
+    <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; <a href='doc_optional.html#tl::optional-T&-::operator=(constoptional&)'>operator=</a>(const <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) = default;
+    
+    optional &amp;operator=(U &amp;&amp;u);
+    
+    template &lt;class U&gt;
+    <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; <a href='doc_optional.html#tl::optional-T&-::operator=(constoptional-U-&)'>operator=</a>(const <a href='doc_optional.html#tl::optional-T-'>optional&lt;U&gt;</a>&amp; rhs);
+    
+    template &lt;class ... Args&gt;
+    T&amp; <a href='doc_optional.html#tl::optional-T&-::emplace(Args&&...)'>emplace</a>(Args&amp;&amp;... args) noexcept;
+    
+    void <a href='doc_optional.html#tl::optional-T&-::swap(optional&)'>swap</a>(<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) noexcept;
+    
+    constexpr const T *operator-&gt;() const;
+    constexpr T *operator-&gt;();
+    
+    constexpr T &amp;operator*();
+    constexpr const T &amp;operator*() const;
+    
+    constexpr bool <a href='doc_optional.html#tl::optional-T&-::has_value()const'>has_value</a>() const noexcept;
+    constexpr <a href='doc_optional.html#tl::optional-T&-::has_value()const'>operator bool</a>() const noexcept;
+    
+    constexpr T&amp; <a href='doc_optional.html#tl::optional-T&-::value()&'>value</a>() &amp;;
+    constexpr const T &amp;value() const;
+    
+    template &lt;class U&gt;
+    constexpr T <a href='doc_optional.html#tl::optional-T&-::value_or(U&&)const&'>value_or</a>(U&amp;&amp; u) const &amp;;
+    template &lt;class U&gt;
+    constexpr T <a href='doc_optional.html#tl::optional-T&-::value_or(U&&)const&'>value_or</a>(U&amp;&amp; u) &amp;&amp;;
+    
+    void <a href='doc_optional.html#tl::optional-T&-::reset()'>reset</a>() noexcept;
+};</code></pre>
 
-\&rhs);
+Specialization for when `T` is a reference. `optional<T&>` acts similarly to a `T*`, but provides more operations and shows intent more clearly.
+
+*Examples*:
+
+    int i = 42;
+    tl::optional<int&> o = i;
+    *o == 42; //true
+    i = 12;
+    *o = 12; //true
+    &*o == &i; //true
+
+Assignment has rebind semantics rather than assign-through semantics:
+
+    int j = 8;
+    o = j;
+    
+    &*o == &j; //true
+
+### Function template `tl::optional<T&>::and_then`<a id="tl::optional-T&-::and_then(F&&)&"></a>
+
+<pre><code class="language-cpp">(1)  template &lt;class F&gt;
+     constexpr auto and_then(F &amp;&amp;f) &amp;;
+
+(2)  template &lt;class F&gt;
+     constexpr auto and_then(F &amp;&amp;f) &amp;&amp;;
+
+(3)  template &lt;class F&gt;
+     constexpr auto and_then(F &amp;&amp;f) const &amp;;
+
+(4)  template &lt;class F&gt;
+     constexpr auto and_then(F &amp;&amp;f) const &amp;&amp;;</code></pre>
+
+Carries out some operation which returns an optional on the stored object if there is one. \\requires `std::invoke(std::forward<F>(f), value())` returns a `std::optional<U>` for some `U`. \\returns Let `U` be the result of `std::invoke(std::forward<F>(f), value())`. Returns a `std::optional<U>`. The return value is empty if `*this` is empty, otherwise the return value of `std::invoke(std::forward<F>(f), value())` is returned.
+
+### Function template `tl::optional<T&>::map`<a id="tl::optional-T&-::map(F&&)&"></a>
+
+<pre><code class="language-cpp">(1)  template &lt;class F&gt; constexpr auto map(F &amp;&amp;f) &amp;;
+
+(2)  template &lt;class F&gt; constexpr auto map(F &amp;&amp;f) &amp;&amp;;
+
+(3)  template &lt;class F&gt; constexpr auto map(F &amp;&amp;f) const&amp;;
+
+(4)  template &lt;class F&gt; constexpr auto map(F &amp;&amp;f) const&amp;&amp;;</code></pre>
+
+Carries out some operation on the stored object if there is one.
+
+*Returns*: Let `U` be the result of `std::invoke(std::forward<F>(f), value())`. Returns a `std::optional<U>`. The return value is empty if `*this` is empty, otherwise an `optional<U>` is constructed from the return value of `std::invoke(std::forward<F>(f), value())` and is returned.
+
+### Function template `tl::optional<T&>::or_else`<a id="tl::optional-T&-::or_else(F&&)&"></a>
+
+<pre><code class="language-cpp">(1)  template &lt;class F&gt; optional&lt;T&gt; or_else (F &amp;&amp;f) &amp;;
+
+(2)  template &lt;class F&gt; optional&lt;T&gt; or_else (F &amp;&amp;f) &amp;&amp;;
+
+(3)  template &lt;class F&gt; optional&lt;T&gt; or_else (F &amp;&amp;f) const &amp;;</code></pre>
+
+Calls `f` if the optional is empty
+
+*Requires*: `std::invoke_result_t<F>` must be void or convertible to `optional<T>`. \\effects If `*this` has a value, returns `*this`. Otherwise, if `f` returns `void`, calls `std::forward<F>(f)` and returns `std::nullopt`. Otherwise, returns `std::forward<F>(f)()`.
+
+### Function template `tl::optional<T&>::map_or`<a id="tl::optional-T&-::map_or(F&&,U&&)&"></a>
+
+<pre><code class="language-cpp">(1)  template &lt;class F, class U&gt;
+     U map_or(F&amp;&amp; f, U&amp;&amp; u) &amp;;
+
+(2)  template &lt;class F, class U&gt;
+     U map_or(F&amp;&amp; f, U&amp;&amp; u) &amp;&amp;;
+
+(3)  template &lt;class F, class U&gt;
+     U map_or(F&amp;&amp; f, U&amp;&amp; u) const &amp;;
+
+(4)  template &lt;class F, class U&gt;
+     U map_or(F&amp;&amp; f, U&amp;&amp; u) const &amp;&amp;;</code></pre>
+
+Maps the stored value with `f` if there is one, otherwise returns `u`.
+
+If there is a value stored, then `f` is called with `**this` and the value is returned. Otherwise `u` is returned.
+
+### Function template `tl::optional<T&>::map_or_else`<a id="tl::optional-T&-::map_or_else(F&&,U&&)&"></a>
+
+<pre><code class="language-cpp">(1)  template &lt;class F, class U&gt;
+     auto map_or_else(F &amp;&amp;f, U &amp;&amp;u) &amp;;
+
+(2)  template &lt;class F, class U&gt;
+     auto map_or_else(F &amp;&amp;f, U &amp;&amp;u)
+
+(3)  template &lt;class F, class U&gt;
+     auto map_or_else(F &amp;&amp;f, U &amp;&amp;u)
+
+(4)  template &lt;class F, class U&gt;
+     auto map_or_else(F &amp;&amp;f, U &amp;&amp;u)</code></pre>
+
+Maps the stored value with `f` if there is one, otherwise calls `u` and returns the result.
+
+If there is a value stored, then `f` is called with `**this` and the value is returned. Otherwise `std::forward<U>(u)()` is returned.
+
+### Function template `tl::optional<T&>::conjunction`<a id="tl::optional-T&-::conjunction(U&&)const"></a>
+
+<pre><code class="language-cpp">template &lt;class U&gt;
+constexpr <a href='doc_optional.html#tl::optional-T-'>optional&lt;typename std::decay&lt;U&gt;::type&gt;</a> conjunction(U&amp;&amp; u) const;</code></pre>
+
+*Returns*: `u` if `*this` has a value, otherwise an empty optional.
+
+### Function `tl::optional<T&>::disjunction`<a id="tl::optional-T&-::disjunction(constoptional&)&"></a>
+
+<pre><code class="language-cpp">(1)  constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> disjunction(const <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) &amp;;
+
+(2)  constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> disjunction(const <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) const &amp;;
+
+(3)  constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> disjunction(const <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) &amp;&amp;;
+
+(4)  constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> disjunction(const <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) const &amp;&amp;;
+
+(5)  constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> disjunction(<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp;&amp; rhs) &amp;;
+
+(6)  constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> disjunction(<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp;&amp; rhs) const &amp;;
+
+(7)  constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> disjunction(<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp;&amp; rhs) &amp;&amp;;
+
+(8)  constexpr <a href='doc_optional.html#tl::optional-T-'>optional</a> disjunction(<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp;&amp; rhs) const &amp;&amp;;</code></pre>
+
+*Returns*: `rhs` if `*this` is empty, otherwise the current value.
+
+### Function `tl::optional<T&>::take`<a id="tl::optional-T&-::take()&"></a>
+
+<pre><code class="language-cpp">(1)  <a href='doc_optional.html#tl::optional-T-'>optional</a> take() &amp;;
+
+(2)  <a href='doc_optional.html#tl::optional-T-'>optional</a> take() const &amp;;
+
+(3)  <a href='doc_optional.html#tl::optional-T-'>optional</a> take() &amp;&amp;;
+
+(4)  <a href='doc_optional.html#tl::optional-T-'>optional</a> take() const &amp;&amp;;</code></pre>
+
+Takes the value out of the optional, leaving it empty
+
+### Default constructor `tl::optional<T&>::optional`<a id="tl::optional-T&-::optional()"></a>
+
+<pre><code class="language-cpp">(1)  constexpr optional() noexcept;
+
+(2)  constexpr optional(<a href='doc_optional.html#tl::nullopt_t'>nullopt_t</a>) noexcept;</code></pre>
+
+Constructs an optional that does not contain a value.
+
+### Copy constructor `tl::optional<T&>::optional`<a id="tl::optional-T&-::optional(constoptional&)"></a>
+
+<pre><code class="language-cpp">constexpr optional(const <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) noexcept = default;</code></pre>
+
+Copy constructor
+
+If `rhs` contains a value, the stored value is direct-initialized with it. Otherwise, the constructed optional is empty.
+
+### Move constructor `tl::optional<T&>::optional`<a id="tl::optional-T&-::optional(optional&&)"></a>
+
+<pre><code class="language-cpp">constexpr optional(<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp;&amp; rhs) = default;</code></pre>
+
+Move constructor
+
+If `rhs` contains a value, the stored value is direct-initialized with it. Otherwise, the constructed optional is empty.
+
+### Function template `tl::optional<T&>::optional`<a id="tl::optional-T&-::optional(U&&)"></a>
+
+<pre><code class="language-cpp">template &lt;class U=T&gt; constexpr optional(U &amp;&amp;u);</code></pre>
+
+Constructs the stored value with `u`.
+
+### Destructor `tl::optional<T&>::~optional`<a id="tl::optional-T&-::~optional()"></a>
+
+<pre><code class="language-cpp">~optional() = default;</code></pre>
+
+No-op
+
+### Assignment operator `tl::optional<T&>::operator=`<a id="tl::optional-T&-::operator=(tl::nullopt_t)"></a>
+
+<pre><code class="language-cpp"><a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; operator=(<a href='doc_optional.html#tl::nullopt_t'>nullopt_t</a>) noexcept;</code></pre>
+
+Assignment to empty.
+
+Destroys the current value if there is one.
+
+### Copy assignment operator `tl::optional<T&>::operator=`<a id="tl::optional-T&-::operator=(constoptional&)"></a>
+
+<pre><code class="language-cpp"><a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; operator=(const <a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) = default;</code></pre>
+
+Copy assignment.
+
+Rebinds this optional to the referee of `rhs` if there is one. Otherwise resets the stored value in `*this`.
+
+### Assignment operator `tl::optional<T&>::operator=`<a id="tl::optional-T&-::operator=(U&&)"></a>
+
+<pre><code class="language-cpp">optional &amp;operator=(U &amp;&amp;u);</code></pre>
+
+Rebinds this optional to `u`.
+
+*Requires*: `U` must be an lvalue reference.
+
+### Assignment operator `tl::optional<T&>::operator=`<a id="tl::optional-T&-::operator=(constoptional-U-&)"></a>
+
+<pre><code class="language-cpp">template &lt;class U&gt;
+<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; operator=(const <a href='doc_optional.html#tl::optional-T-'>optional&lt;U&gt;</a>&amp; rhs);</code></pre>
+
+Converting copy assignment operator.
+
+Rebinds this optional to the referee of `rhs` if there is one. Otherwise resets the stored value in `*this`.
+
+### Function template `tl::optional<T&>::emplace`<a id="tl::optional-T&-::emplace(Args&&...)"></a>
+
+<pre><code class="language-cpp">(1)  template &lt;class ... Args&gt;
+     T&amp; emplace(Args&amp;&amp;... args) noexcept;</code></pre>
+
+Constructs the value in-place, destroying the current one if there is one.
+
+### Function `tl::optional<T&>::swap`<a id="tl::optional-T&-::swap(optional&)"></a>
+
+<pre><code class="language-cpp">void swap(<a href='doc_optional.html#tl::optional-T-'>optional</a>&amp; rhs) noexcept;</code></pre>
+
+Swaps this optional with the other.
+
+If neither optionals have a value, nothing happens. If both have a value, the values are swapped. If one has a value, it is moved to the other and the movee is left valueless.
+
+### Operator `tl::optional<T&>::operator->`<a id="tl::optional-T&-::operator--()const"></a>
+
+<pre><code class="language-cpp">(1)  constexpr const T *operator-&gt;() const;
+
+(2)  constexpr T *operator-&gt;();</code></pre>
+
+*Returns*: a pointer to the stored value
+
+*Requires*: a value is stored
+
+### Operator `tl::optional<T&>::operator*`<a id="tl::optional-T&-::operator*()&"></a>
+
+<pre><code class="language-cpp">(1)  constexpr T &amp;operator*();
+
+(2)  constexpr const T &amp;operator*() const;</code></pre>
+
+*Returns*: the stored value
+
+*Requires*: a value is stored
+
+### Function `tl::optional<T&>::has_value`<a id="tl::optional-T&-::has_value()const"></a>
+
+<pre><code class="language-cpp">(1)  constexpr bool has_value() const noexcept;
+
+(2)  constexpr operator bool() const noexcept;</code></pre>
+
+*Returns*: whether or not the optional has a value
+
+### Function `tl::optional<T&>::value`<a id="tl::optional-T&-::value()&"></a>
+
+<pre><code class="language-cpp">(1)  constexpr T&amp; value() &amp;;
+
+(2)  constexpr const T &amp;value() const;</code></pre>
+
+*Returns*: the contained value if there is one, otherwise throws \[bad\_optional\_access\]
+
+synopsis constexpr T \&value();
+
+### Function template `tl::optional<T&>::value_or`<a id="tl::optional-T&-::value_or(U&&)const&"></a>
+
+<pre><code class="language-cpp">(1)  template &lt;class U&gt;
+     constexpr T value_or(U&amp;&amp; u) const &amp;;
+
+(2)  template &lt;class U&gt;
+     constexpr T value_or(U&amp;&amp; u) &amp;&amp;;</code></pre>
+
+*Returns*: the stored value if there is one, otherwise returns `u`
+
+### Function `tl::optional<T&>::reset`<a id="tl::optional-T&-::reset()"></a>
+
+<pre><code class="language-cpp">void reset() noexcept;</code></pre>
+
+Destroys the stored value if one exists, making the optional empty
+
+-----
 
 -----

--- a/standardese.config
+++ b/standardese.config
@@ -1,0 +1,3 @@
+[output]
+format=commonmark
+link_extension=html

--- a/tests/assignment.cpp
+++ b/tests/assignment.cpp
@@ -1,7 +1,7 @@
 #include "catch.hpp"
 #include "optional.hpp"
 
-TEST_CASE("Assignment", "[assignment]") {
+TEST_CASE("Assignment value", "[assignment.value]") {
     tl::optional<int> o1 = 42;
     tl::optional<int> o2 = 12;
     tl::optional<int> o3;
@@ -31,4 +31,38 @@ TEST_CASE("Assignment", "[assignment]") {
 
     o1 = std::move(o4);
     REQUIRE(*o1 == 42);
+}
+
+
+TEST_CASE("Assignment reference", "[assignment.ref]") {
+    auto i = 42;
+    auto j = 12;
+    
+    tl::optional<int&> o1 = i;
+    tl::optional<int&> o2 = j;
+    tl::optional<int&> o3;
+
+    o1 = o1;
+    REQUIRE(*o1 == 42);
+    REQUIRE(&*o1 == &i);    
+
+    o1 = o2;
+    REQUIRE(*o1 == 12);
+
+    o1 = o3;
+    REQUIRE(!o1);
+
+    auto k = 42;
+    o1 = k;
+    REQUIRE(*o1 == 42);
+    REQUIRE(*o1 == i);
+    REQUIRE(*o1 == k);        
+    REQUIRE(&*o1 != &i);
+    REQUIRE(&*o1 == &k);            
+
+    o1 = tl::nullopt;
+    REQUIRE(!o1);
+
+    o1 = std::move(o2);
+    REQUIRE(*o1 == 12);
 }

--- a/tests/assignment.cpp
+++ b/tests/assignment.cpp
@@ -58,7 +58,10 @@ TEST_CASE("Assignment reference", "[assignment.ref]") {
     REQUIRE(*o1 == i);
     REQUIRE(*o1 == k);        
     REQUIRE(&*o1 != &i);
-    REQUIRE(&*o1 == &k);            
+    REQUIRE(&*o1 == &k);
+
+    k = 12;
+    REQUIRE(*o1 == 12);
 
     o1 = tl::nullopt;
     REQUIRE(!o1);

--- a/tests/constructors.cpp
+++ b/tests/constructors.cpp
@@ -2,30 +2,49 @@
 #include "optional.hpp"
 
 TEST_CASE("Constructors", "[constructors]") {
-    tl::optional<int> o1;
-    REQUIRE(!o1);
+  tl::optional<int> o1;
+  REQUIRE(!o1);
 
-    tl::optional<int> o2 = tl::nullopt;
-    REQUIRE(!o2);
+  tl::optional<int> o2 = tl::nullopt;
+  REQUIRE(!o2);
 
-    tl::optional<int> o3 = 42;
-    REQUIRE(*o3 == 42);
+  tl::optional<int> o3 = 42;
+  REQUIRE(*o3 == 42);
 
-    tl::optional<int> o4 = o3;
-    REQUIRE(*o4 == 42);
+  tl::optional<int> o4 = o3;
+  REQUIRE(*o4 == 42);
 
-    tl::optional<int> o5 = o1;
-    REQUIRE(!o5);
+  tl::optional<int> o5 = o1;
+  REQUIRE(!o5);
 
-    tl::optional<int> o6 = std::move(o3);
-    REQUIRE(*o6 == 42);
+  tl::optional<int> o6 = std::move(o3);
+  REQUIRE(*o6 == 42);
 
-    tl::optional<short> o7 = 42;
-    REQUIRE(*o7 == 42);
+  tl::optional<short> o7 = 42;
+  REQUIRE(*o7 == 42);
 
-    tl::optional<int> o8 = o7;
-    REQUIRE(*o8 == 42);
+  tl::optional<int> o8 = o7;
+  REQUIRE(*o8 == 42);
 
-    tl::optional<int> o9 = std::move(o7);
-    REQUIRE(*o9 == 42);
+  tl::optional<int> o9 = std::move(o7);
+  REQUIRE(*o9 == 42);
+
+  {
+    tl::optional<int &> o;
+    REQUIRE(!o);
+
+    tl::optional<int &> oo = o;
+    REQUIRE(!oo);
+  }
+
+  {
+    auto i = 42;
+    tl::optional<int &> o = i;
+    REQUIRE(o);
+    REQUIRE(*o == 42);
+
+    tl::optional<int &> oo = o;
+    REQUIRE(oo);
+    REQUIRE(*oo == 42);
+  }
 }

--- a/tests/extensions.cpp
+++ b/tests/extensions.cpp
@@ -122,7 +122,7 @@ TEST_CASE("Monadic operations", "[monadic]") {
 
     // callable which returns a reference
     tl::optional<int> o38 = 42;
-    auto o38r = o38.map([](int& i) -> const int& { return i; });
+    auto o38r = o38.map([](int &i) -> const int & { return i; });
     REQUIRE(o38r);
     REQUIRE(*o38r == 42);
   }

--- a/tests/make_optional.cpp
+++ b/tests/make_optional.cpp
@@ -37,4 +37,8 @@ TEST_CASE("Make optional", "[make_optional]") {
   REQUIRE(o5->v[1] == 1);
   REQUIRE(std::get<0>(o5->t) == 2);
   REQUIRE(std::get<1>(o5->t) == 3);
+
+  auto i = 42;
+  auto o6 = tl::make_optional<int&>(i);
+  REQUIRE((std::is_same<decltype(o6), tl::optional<int&>>::value));
 }

--- a/tests/make_optional.cpp
+++ b/tests/make_optional.cpp
@@ -41,4 +41,6 @@ TEST_CASE("Make optional", "[make_optional]") {
   auto i = 42;
   auto o6 = tl::make_optional<int&>(i);
   REQUIRE((std::is_same<decltype(o6), tl::optional<int&>>::value));
+  REQUIRE(o6);
+  REQUIRE(*o6 == 42);    
 }

--- a/tl/optional.hpp
+++ b/tl/optional.hpp
@@ -72,339 +72,337 @@
 #define TL_OPTIONAL_11_CONSTEXPR constexpr
 #endif
 
-    namespace tl {
+namespace tl {
 #ifndef TL_MONOSTATE_INPLACE_MUTEX
 #define TL_MONOSTATE_INPLACE_MUTEX
-  /// \brief Used to represent an optional with no data; essentially a bool
-  class monostate {};
+/// \brief Used to represent an optional with no data; essentially a bool
+class monostate {};
 
-  /// \brief A tag type to tell optional to construct its value in-place
-  struct in_place_t {
-    explicit in_place_t() = default;
-  };
-  /// \brief A tag to tell optional to construct its value in-place
-  static constexpr in_place_t in_place{};
+/// \brief A tag type to tell optional to construct its value in-place
+struct in_place_t {
+  explicit in_place_t() = default;
+};
+/// \brief A tag to tell optional to construct its value in-place
+static constexpr in_place_t in_place{};
 #endif
 
-  template <class T> class optional;
+template <class T> class optional;
 
-  /// \exclude
-  namespace detail {
+/// \exclude
+namespace detail {
 #ifndef TL_TRAITS_MUTEX
 #define TL_TRAITS_MUTEX
-  // C++14-style aliases for brevity
-  template <class T> using remove_const_t = typename std::remove_const<T>::type;
-  template <class T>
-  using remove_reference_t = typename std::remove_reference<T>::type;
-  template <class T> using decay_t = typename std::decay<T>::type;
-  template <bool E, class T = void>
-  using enable_if_t = typename std::enable_if<E, T>::type;
-  template <bool B, class T, class F>
-  using conditional_t = typename std::conditional<B, T, F>::type;
+// C++14-style aliases for brevity
+template <class T> using remove_const_t = typename std::remove_const<T>::type;
+template <class T>
+using remove_reference_t = typename std::remove_reference<T>::type;
+template <class T> using decay_t = typename std::decay<T>::type;
+template <bool E, class T = void>
+using enable_if_t = typename std::enable_if<E, T>::type;
+template <bool B, class T, class F>
+using conditional_t = typename std::conditional<B, T, F>::type;
 
-  // std::conjunction from C++17
-  template <class...> struct conjunction : std::true_type {};
-  template <class B> struct conjunction<B> : B {};
-  template <class B, class... Bs>
-  struct conjunction<B, Bs...>
-      : std::conditional<bool(B::value), conjunction<Bs...>, B>::type {};
+// std::conjunction from C++17
+template <class...> struct conjunction : std::true_type {};
+template <class B> struct conjunction<B> : B {};
+template <class B, class... Bs>
+struct conjunction<B, Bs...>
+    : std::conditional<bool(B::value), conjunction<Bs...>, B>::type {};
 
-  // std::invoke from C++17
-  // https://stackoverflow.com/questions/38288042/c11-14-invoke-workaround
-  template <typename Fn, typename... Args,
-            typename = enable_if_t<std::is_member_pointer<decay_t<Fn>>{}>,
-            int = 0>
-  constexpr auto invoke(Fn &&f, Args &&... args) noexcept(
-      noexcept(std::mem_fn(f)(std::forward<Args>(args)...)))
-      -> decltype(std::mem_fn(f)(std::forward<Args>(args)...)) {
-    return std::mem_fn(f)(std::forward<Args>(args)...);
-  }
+// std::invoke from C++17
+// https://stackoverflow.com/questions/38288042/c11-14-invoke-workaround
+template <typename Fn, typename... Args,
+          typename = enable_if_t<std::is_member_pointer<decay_t<Fn>>{}>,
+          int = 0>
+constexpr auto invoke(Fn &&f, Args &&... args) noexcept(
+    noexcept(std::mem_fn(f)(std::forward<Args>(args)...)))
+    -> decltype(std::mem_fn(f)(std::forward<Args>(args)...)) {
+  return std::mem_fn(f)(std::forward<Args>(args)...);
+}
 
-  template <typename Fn, typename... Args,
-            typename = enable_if_t<!std::is_member_pointer<decay_t<Fn>>{}>>
-  constexpr auto invoke(Fn &&f, Args &&... args) noexcept(
-      noexcept(std::forward<Fn>(f)(std::forward<Args>(args)...)))
-      -> decltype(std::forward<Fn>(f)(std::forward<Args>(args)...)) {
-    return std::forward<Fn>(f)(std::forward<Args>(args)...);
-  }
+template <typename Fn, typename... Args,
+          typename = enable_if_t<!std::is_member_pointer<decay_t<Fn>>{}>>
+constexpr auto invoke(Fn &&f, Args &&... args) noexcept(
+    noexcept(std::forward<Fn>(f)(std::forward<Args>(args)...)))
+    -> decltype(std::forward<Fn>(f)(std::forward<Args>(args)...)) {
+  return std::forward<Fn>(f)(std::forward<Args>(args)...);
+}
 
-  // std::invoke_result from C++17
-  template <class F, class, class... Us> struct invoke_result_impl;
+// std::invoke_result from C++17
+template <class F, class, class... Us> struct invoke_result_impl;
 
-  template <class F, class... Us>
-  struct invoke_result_impl<
-      F, decltype(invoke(std::declval<F>(), std::declval<Us>()...), void()),
-      Us...> {
-    using type = decltype(invoke(std::declval<F>(), std::declval<Us>()...));
-  };
+template <class F, class... Us>
+struct invoke_result_impl<
+    F, decltype(invoke(std::declval<F>(), std::declval<Us>()...), void()),
+    Us...> {
+  using type = decltype(invoke(std::declval<F>(), std::declval<Us>()...));
+};
 
-  template <class F, class... Us>
-  using invoke_result = invoke_result_impl<F, void, Us...>;
+template <class F, class... Us>
+using invoke_result = invoke_result_impl<F, void, Us...>;
 
-  template <class F, class... Us>
-  using invoke_result_t = typename invoke_result<F, Us...>::type;
+template <class F, class... Us>
+using invoke_result_t = typename invoke_result<F, Us...>::type;
 #endif
 
-  // std::void_t from C++17
-  template <class...> struct voider { using type = void; };
-  template <class... Ts> using void_t = typename voider<Ts...>::type;
+// std::void_t from C++17
+template <class...> struct voider { using type = void; };
+template <class... Ts> using void_t = typename voider<Ts...>::type;
 
-  // Trait for checking if a type is a tl::optional
-  template <class T> struct is_optional_impl : std::false_type {};
-  template <class T> struct is_optional_impl<optional<T>> : std::true_type {};
-  template <class T> using is_optional = is_optional_impl<decay_t<T>>;
+// Trait for checking if a type is a tl::optional
+template <class T> struct is_optional_impl : std::false_type {};
+template <class T> struct is_optional_impl<optional<T>> : std::true_type {};
+template <class T> using is_optional = is_optional_impl<decay_t<T>>;
 
-  // Change void to tl::monostate
-  template <class U>
-  using fixup_void = conditional_t<std::is_void<U>::value, monostate, U>;
+// Change void to tl::monostate
+template <class U>
+using fixup_void = conditional_t<std::is_void<U>::value, monostate, U>;
 
-  template <class F, class U, class = invoke_result_t<F, U>>
-  using get_map_return = optional<fixup_void<invoke_result_t<F, U>>>;
+template <class F, class U, class = invoke_result_t<F, U>>
+using get_map_return = optional<fixup_void<invoke_result_t<F, U>>>;
 
-  // Check if invoking F for some Us returns void
-  template <class F, class = void, class... U> struct returns_void_impl;
-  template <class F, class... U>
-  struct returns_void_impl<F, void_t<invoke_result_t<F, U...>>, U...>
-      : std::is_void<invoke_result_t<F, U...>> {};
-  template <class F, class... U>
-  using returns_void = returns_void_impl<F, void, U...>;
+// Check if invoking F for some Us returns void
+template <class F, class = void, class... U> struct returns_void_impl;
+template <class F, class... U>
+struct returns_void_impl<F, void_t<invoke_result_t<F, U...>>, U...>
+    : std::is_void<invoke_result_t<F, U...>> {};
+template <class F, class... U>
+using returns_void = returns_void_impl<F, void, U...>;
 
-  template <class T, class... U>
-  using enable_if_ret_void = enable_if_t<returns_void<T &&, U...>::value>;
+template <class T, class... U>
+using enable_if_ret_void = enable_if_t<returns_void<T &&, U...>::value>;
 
-  template <class T, class... U>
-  using disable_if_ret_void = enable_if_t<!returns_void<T &&, U...>::value>;
+template <class T, class... U>
+using disable_if_ret_void = enable_if_t<!returns_void<T &&, U...>::value>;
 
-  template <class T, class U>
-  using enable_forward_value = detail::enable_if_t<
-      std::is_constructible<T, U &&>::value &&
-      !std::is_same<detail::decay_t<U>, in_place_t>::value &&
-      !std::is_same<optional<T>, detail::decay_t<U>>::value>;
+template <class T, class U>
+using enable_forward_value =
+    detail::enable_if_t<std::is_constructible<T, U &&>::value &&
+                        !std::is_same<detail::decay_t<U>, in_place_t>::value &&
+                        !std::is_same<optional<T>, detail::decay_t<U>>::value>;
 
-  template <class T, class U, class Other>
-  using enable_from_other = detail::enable_if_t<
-      std::is_constructible<T, Other>::value &&
-      !std::is_constructible<T, optional<U> &>::value &&
-      !std::is_constructible<T, optional<U> &&>::value &&
-      !std::is_constructible<T, const optional<U> &>::value &&
-      !std::is_constructible<T, const optional<U> &&>::value &&
-      !std::is_convertible<optional<U> &, T>::value &&
-      !std::is_convertible<optional<U> &&, T>::value &&
-      !std::is_convertible<const optional<U> &, T>::value &&
-      !std::is_convertible<const optional<U> &&, T>::value>;
+template <class T, class U, class Other>
+using enable_from_other = detail::enable_if_t<
+    std::is_constructible<T, Other>::value &&
+    !std::is_constructible<T, optional<U> &>::value &&
+    !std::is_constructible<T, optional<U> &&>::value &&
+    !std::is_constructible<T, const optional<U> &>::value &&
+    !std::is_constructible<T, const optional<U> &&>::value &&
+    !std::is_convertible<optional<U> &, T>::value &&
+    !std::is_convertible<optional<U> &&, T>::value &&
+    !std::is_convertible<const optional<U> &, T>::value &&
+    !std::is_convertible<const optional<U> &&, T>::value>;
 
-  template <class T, class U>
-  using enable_assign_forward = detail::enable_if_t<
-      !std::is_same<optional<T>, detail::decay_t<U>>::value &&
-      !detail::conjunction<std::is_scalar<T>,
-                           std::is_same<T, detail::decay_t<U>>>::value &&
-      std::is_constructible<T, U>::value && std::is_assignable<T &, U>::value>;
+template <class T, class U>
+using enable_assign_forward = detail::enable_if_t<
+    !std::is_same<optional<T>, detail::decay_t<U>>::value &&
+    !detail::conjunction<std::is_scalar<T>,
+                         std::is_same<T, detail::decay_t<U>>>::value &&
+    std::is_constructible<T, U>::value && std::is_assignable<T &, U>::value>;
 
-  template <class T, class U, class Other>
-  using enable_assign_from_other = detail::enable_if_t<
-      std::is_constructible<T, Other>::value &&
-      std::is_assignable<T &, Other>::value &&
-      !std::is_constructible<T, optional<U> &>::value &&
-      !std::is_constructible<T, optional<U> &&>::value &&
-      !std::is_constructible<T, const optional<U> &>::value &&
-      !std::is_constructible<T, const optional<U> &&>::value &&
-      !std::is_convertible<optional<U> &, T>::value &&
-      !std::is_convertible<optional<U> &&, T>::value &&
-      !std::is_convertible<const optional<U> &, T>::value &&
-      !std::is_convertible<const optional<U> &&, T>::value &&
-      !std::is_assignable<T &, optional<U> &>::value &&
-      !std::is_assignable<T &, optional<U> &&>::value &&
-      !std::is_assignable<T &, const optional<U> &>::value &&
-      !std::is_assignable<T &, const optional<U> &&>::value>;
+template <class T, class U, class Other>
+using enable_assign_from_other = detail::enable_if_t<
+    std::is_constructible<T, Other>::value &&
+    std::is_assignable<T &, Other>::value &&
+    !std::is_constructible<T, optional<U> &>::value &&
+    !std::is_constructible<T, optional<U> &&>::value &&
+    !std::is_constructible<T, const optional<U> &>::value &&
+    !std::is_constructible<T, const optional<U> &&>::value &&
+    !std::is_convertible<optional<U> &, T>::value &&
+    !std::is_convertible<optional<U> &&, T>::value &&
+    !std::is_convertible<const optional<U> &, T>::value &&
+    !std::is_convertible<const optional<U> &&, T>::value &&
+    !std::is_assignable<T &, optional<U> &>::value &&
+    !std::is_assignable<T &, optional<U> &&>::value &&
+    !std::is_assignable<T &, const optional<U> &>::value &&
+    !std::is_assignable<T &, const optional<U> &&>::value>;
 
 #ifdef _MSC_VER
-  // TODO make a version which works with MSVC
-  template <class T, class U = T> struct is_swappable : std::true_type {};
+// TODO make a version which works with MSVC
+template <class T, class U = T> struct is_swappable : std::true_type {};
 
-  template <class T, class U = T>
-  struct is_nothrow_swappable : std::true_type {};
+template <class T, class U = T> struct is_nothrow_swappable : std::true_type {};
 #else
-  // https://stackoverflow.com/questions/26744589/what-is-a-proper-way-to-implement-is-swappable-to-test-for-the-swappable-concept
-  namespace swap_adl_tests {
-  // if swap ADL finds this then it would call std::swap otherwise (same
-  // signature)
-  struct tag {};
+// https://stackoverflow.com/questions/26744589/what-is-a-proper-way-to-implement-is-swappable-to-test-for-the-swappable-concept
+namespace swap_adl_tests {
+// if swap ADL finds this then it would call std::swap otherwise (same
+// signature)
+struct tag {};
 
-  template <class T> tag swap(T &, T &);
-  template <class T, std::size_t N> tag swap(T (&a)[N], T (&b)[N]);
+template <class T> tag swap(T &, T &);
+template <class T, std::size_t N> tag swap(T (&a)[N], T (&b)[N]);
 
-  // helper functions to test if an unqualified swap is possible, and if it
-  // becomes std::swap
-  template <class, class> std::false_type can_swap(...) noexcept(false);
-  template <class T, class U,
-            class = decltype(swap(std::declval<T &>(), std::declval<U &>()))>
-  std::true_type can_swap(int) noexcept(noexcept(swap(std::declval<T &>(),
-                                                      std::declval<U &>())));
+// helper functions to test if an unqualified swap is possible, and if it
+// becomes std::swap
+template <class, class> std::false_type can_swap(...) noexcept(false);
+template <class T, class U,
+          class = decltype(swap(std::declval<T &>(), std::declval<U &>()))>
+std::true_type can_swap(int) noexcept(noexcept(swap(std::declval<T &>(),
+                                                    std::declval<U &>())));
 
-  template <class, class> std::false_type uses_std(...);
-  template <class T, class U>
-  std::is_same<decltype(swap(std::declval<T &>(), std::declval<U &>())), tag>
-  uses_std(int);
+template <class, class> std::false_type uses_std(...);
+template <class T, class U>
+std::is_same<decltype(swap(std::declval<T &>(), std::declval<U &>())), tag>
+uses_std(int);
 
-  template <class T>
-  struct is_std_swap_noexcept
-      : std::integral_constant<bool,
-                               std::is_nothrow_move_constructible<T>::value &&
-                                   std::is_nothrow_move_assignable<T>::value> {
-  };
+template <class T>
+struct is_std_swap_noexcept
+    : std::integral_constant<bool,
+                             std::is_nothrow_move_constructible<T>::value &&
+                                 std::is_nothrow_move_assignable<T>::value> {};
 
-  template <class T, std::size_t N>
-  struct is_std_swap_noexcept<T[N]> : is_std_swap_noexcept<T> {};
+template <class T, std::size_t N>
+struct is_std_swap_noexcept<T[N]> : is_std_swap_noexcept<T> {};
 
-  template <class T, class U>
-  struct is_adl_swap_noexcept
-      : std::integral_constant<bool, noexcept(can_swap<T, U>(0))> {};
-  } // namespace swap_adl_tests
+template <class T, class U>
+struct is_adl_swap_noexcept
+    : std::integral_constant<bool, noexcept(can_swap<T, U>(0))> {};
+} // namespace swap_adl_tests
 
-  template <class T, class U = T>
-  struct is_swappable
-      : std::integral_constant<
-            bool,
-            decltype(detail::swap_adl_tests::can_swap<T, U>(0))::value &&
-                (!decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value ||
-                 (std::is_move_assignable<T>::value &&
-                  std::is_move_constructible<T>::value))> {};
+template <class T, class U = T>
+struct is_swappable
+    : std::integral_constant<
+          bool,
+          decltype(detail::swap_adl_tests::can_swap<T, U>(0))::value &&
+              (!decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value ||
+               (std::is_move_assignable<T>::value &&
+                std::is_move_constructible<T>::value))> {};
 
-  template <class T, std::size_t N>
-  struct is_swappable<T[N], T[N]>
-      : std::integral_constant<
-            bool,
-            decltype(detail::swap_adl_tests::can_swap<T[N], T[N]>(0))::value &&
-                (!decltype(
-                     detail::swap_adl_tests::uses_std<T[N], T[N]>(0))::value ||
-                 is_swappable<T, T>::value)> {};
+template <class T, std::size_t N>
+struct is_swappable<T[N], T[N]>
+    : std::integral_constant<
+          bool,
+          decltype(detail::swap_adl_tests::can_swap<T[N], T[N]>(0))::value &&
+              (!decltype(
+                   detail::swap_adl_tests::uses_std<T[N], T[N]>(0))::value ||
+               is_swappable<T, T>::value)> {};
 
-  template <class T, class U = T>
-  struct is_nothrow_swappable
-      : std::integral_constant<
-            bool,
-            is_swappable<T, U>::value &&
-                ((decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value &&
-                      detail::swap_adl_tests::is_std_swap_noexcept<T>::value) ||
-                 (!decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value
-                      &&detail::swap_adl_tests::is_adl_swap_noexcept<
-                          T, U>::value))> {};
+template <class T, class U = T>
+struct is_nothrow_swappable
+    : std::integral_constant<
+          bool,
+          is_swappable<T, U>::value &&
+              ((decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value
+                    &&detail::swap_adl_tests::is_std_swap_noexcept<T>::value) ||
+               (!decltype(detail::swap_adl_tests::uses_std<T, U>(0))::value &&
+                    detail::swap_adl_tests::is_adl_swap_noexcept<T,
+                                                                 U>::value))> {
+};
 #endif
 
-  // The storage base manages the actual storage, and correctly propagates
-  // trivial destruction from T This case is for when T is trivially
-  // destructible
-  template <class T, bool = ::std::is_trivially_destructible<T>::value>
-  struct optional_storage_base {
-    TL_OPTIONAL_11_CONSTEXPR optional_storage_base() noexcept
-        : m_dummy(), m_has_value(false) {}
+// The storage base manages the actual storage, and correctly propagates
+// trivial destruction from T This case is for when T is trivially
+// destructible
+template <class T, bool = ::std::is_trivially_destructible<T>::value>
+struct optional_storage_base {
+  TL_OPTIONAL_11_CONSTEXPR optional_storage_base() noexcept
+      : m_dummy(), m_has_value(false) {}
 
-    template <class... U>
-    TL_OPTIONAL_11_CONSTEXPR optional_storage_base(in_place_t, U &&... u)
-        : m_value(std::forward<U>(u)...), m_has_value(true) {}
+  template <class... U>
+  TL_OPTIONAL_11_CONSTEXPR optional_storage_base(in_place_t, U &&... u)
+      : m_value(std::forward<U>(u)...), m_has_value(true) {}
 
-    ~optional_storage_base() {
-      if (m_has_value) {
-        m_value.~T();
-        m_has_value = false;
-      }
+  ~optional_storage_base() {
+    if (m_has_value) {
+      m_value.~T();
+      m_has_value = false;
     }
+  }
 
-    struct dummy {};
-    union {
-      dummy m_dummy;
-      T m_value;
-    };
-
-    bool m_has_value;
+  struct dummy {};
+  union {
+    dummy m_dummy;
+    T m_value;
   };
 
-  // This case is for when T is not trivially destructible
-  template <class T> struct optional_storage_base<T, true> {
-    TL_OPTIONAL_11_CONSTEXPR optional_storage_base() noexcept
-        : m_dummy(), m_has_value(false) {}
+  bool m_has_value;
+};
 
-    template <class... U>
-    TL_OPTIONAL_11_CONSTEXPR optional_storage_base(in_place_t, U &&... u)
-        : m_value(std::forward<U>(u)...), m_has_value(true) {}
+// This case is for when T is not trivially destructible
+template <class T> struct optional_storage_base<T, true> {
+  TL_OPTIONAL_11_CONSTEXPR optional_storage_base() noexcept
+      : m_dummy(), m_has_value(false) {}
 
-    // No destructor, so this class is trivially destructible
+  template <class... U>
+  TL_OPTIONAL_11_CONSTEXPR optional_storage_base(in_place_t, U &&... u)
+      : m_value(std::forward<U>(u)...), m_has_value(true) {}
 
-    struct dummy {};
-    union {
-      dummy m_dummy;
-      T m_value;
-    };
+  // No destructor, so this class is trivially destructible
 
-    bool m_has_value = false;
+  struct dummy {};
+  union {
+    dummy m_dummy;
+    T m_value;
   };
 
-  // This base class provides some handy member functions which can be used in
-  // further derived classes
-  template <class T>
-  struct optional_operations_base : optional_storage_base<T> {
-    using optional_storage_base<T>::optional_storage_base;
+  bool m_has_value = false;
+};
 
-    void hard_reset() noexcept {
-      get().~T();
-      this->m_has_value = false;
-    }
+// This base class provides some handy member functions which can be used in
+// further derived classes
+template <class T> struct optional_operations_base : optional_storage_base<T> {
+  using optional_storage_base<T>::optional_storage_base;
 
-    template <class... Args> void construct(Args &&... args) noexcept {
-      new (std::addressof(this->m_value)) T(std::forward<Args>(args)...);
-      this->m_has_value = true;
-    }
+  void hard_reset() noexcept {
+    get().~T();
+    this->m_has_value = false;
+  }
 
-    template <class Opt> void assign(Opt &&rhs) {
-      if (this->has_value()) {
-        if (rhs.has_value()) {
-          this->m_value = std::forward<Opt>(rhs).get();
-        } else {
-          this->m_value.~T();
-          this->m_has_value = false;
-        }
-      }
+  template <class... Args> void construct(Args &&... args) noexcept {
+    new (std::addressof(this->m_value)) T(std::forward<Args>(args)...);
+    this->m_has_value = true;
+  }
 
+  template <class Opt> void assign(Opt &&rhs) {
+    if (this->has_value()) {
       if (rhs.has_value()) {
-        construct(std::forward<Opt>(rhs).get());
-      }
-    }
-
-    bool has_value() const { return this->m_has_value; }
-
-    TL_OPTIONAL_11_CONSTEXPR T &get() & { return this->m_value; }
-    TL_OPTIONAL_11_CONSTEXPR const T &get() const & { return this->m_value; }
-    TL_OPTIONAL_11_CONSTEXPR T &&get() && { std::move(this->m_value); }
-#ifndef TL_OPTIONAL_NO_CONSTRR
-    constexpr const T &&get() const && { return std::move(this->m_value); }
-#endif
-  };
-
-  // This class manages conditionally having a trivial copy constructor
-  // This specialization is for when T is trivially copy constructible
-  template <class T, bool = IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T)>
-  struct optional_copy_base : optional_operations_base<T> {
-    using optional_operations_base<T>::optional_operations_base;
-  };
-
-  // This specialization is for when T is not trivially copy constructible
-  template <class T>
-  struct optional_copy_base<T, false> : optional_operations_base<T> {
-    using optional_operations_base<T>::optional_operations_base;
-
-    optional_copy_base() = default;
-    optional_copy_base(const optional_copy_base &rhs) {
-      if (rhs.has_value()) {
-        this->construct(rhs.get());
+        this->m_value = std::forward<Opt>(rhs).get();
       } else {
+        this->m_value.~T();
         this->m_has_value = false;
       }
     }
 
-    optional_copy_base(optional_copy_base &&rhs) = default;
-    optional_copy_base &operator=(const optional_copy_base &rhs) = default;
-    optional_copy_base &operator=(optional_copy_base &&rhs) = default;
-  };
+    if (rhs.has_value()) {
+      construct(std::forward<Opt>(rhs).get());
+    }
+  }
+
+  bool has_value() const { return this->m_has_value; }
+
+  TL_OPTIONAL_11_CONSTEXPR T &get() & { return this->m_value; }
+  TL_OPTIONAL_11_CONSTEXPR const T &get() const & { return this->m_value; }
+  TL_OPTIONAL_11_CONSTEXPR T &&get() && { std::move(this->m_value); }
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  constexpr const T &&get() const && { return std::move(this->m_value); }
+#endif
+};
+
+// This class manages conditionally having a trivial copy constructor
+// This specialization is for when T is trivially copy constructible
+template <class T, bool = IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T)>
+struct optional_copy_base : optional_operations_base<T> {
+  using optional_operations_base<T>::optional_operations_base;
+};
+
+// This specialization is for when T is not trivially copy constructible
+template <class T>
+struct optional_copy_base<T, false> : optional_operations_base<T> {
+  using optional_operations_base<T>::optional_operations_base;
+
+  optional_copy_base() = default;
+  optional_copy_base(const optional_copy_base &rhs) {
+    if (rhs.has_value()) {
+      this->construct(rhs.get());
+    } else {
+      this->m_has_value = false;
+    }
+  }
+
+  optional_copy_base(optional_copy_base &&rhs) = default;
+  optional_copy_base &operator=(const optional_copy_base &rhs) = default;
+  optional_copy_base &operator=(optional_copy_base &&rhs) = default;
+};
 
 // This class manages conditionally having a trivial move constructor
 // Unfortunately there's no way to achieve this in GCC < 5 AFAIK, since it
@@ -412,55 +410,54 @@
 // have to make do with a non-trivial move constructor even if T is trivially
 // move constructible
 #ifndef TL_OPTIONAL_GCC49
-  template <class T, bool = std::is_trivially_move_constructible<T>::value>
-  struct optional_move_base : optional_copy_base<T> {
-    using optional_copy_base<T>::optional_copy_base;
-  };
+template <class T, bool = std::is_trivially_move_constructible<T>::value>
+struct optional_move_base : optional_copy_base<T> {
+  using optional_copy_base<T>::optional_copy_base;
+};
 #else
-  template <class T, bool = false> struct optional_move_base;
+template <class T, bool = false> struct optional_move_base;
 #endif
-  template <class T>
-  struct optional_move_base<T, false> : optional_copy_base<T> {
-    using optional_copy_base<T>::optional_copy_base;
+template <class T> struct optional_move_base<T, false> : optional_copy_base<T> {
+  using optional_copy_base<T>::optional_copy_base;
 
-    optional_move_base() = default;
-    optional_move_base(const optional_move_base &rhs) = default;
+  optional_move_base() = default;
+  optional_move_base(const optional_move_base &rhs) = default;
 
-    optional_move_base(optional_move_base &&rhs) noexcept(
-        std::is_nothrow_move_constructible<T>::value) {
-      if (rhs.has_value()) {
-        this->construct(std::move(rhs.get()));
-      } else {
-        this->m_has_value = false;
-      }
+  optional_move_base(optional_move_base &&rhs) noexcept(
+      std::is_nothrow_move_constructible<T>::value) {
+    if (rhs.has_value()) {
+      this->construct(std::move(rhs.get()));
+    } else {
+      this->m_has_value = false;
     }
-    optional_move_base &operator=(const optional_move_base &rhs) = default;
-    optional_move_base &operator=(optional_move_base &&rhs) = default;
-  };
+  }
+  optional_move_base &operator=(const optional_move_base &rhs) = default;
+  optional_move_base &operator=(optional_move_base &&rhs) = default;
+};
 
-  // This class manages conditionally having a trivial copy assignment operator
-  template <class T, bool = IS_TRIVIALLY_COPY_ASSIGNABLE(T) &&
-                            IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T) &&
-                            IS_TRIVIALLY_DESTRUCTIBLE(T)>
-  struct optional_copy_assign_base : optional_move_base<T> {
-    using optional_move_base<T>::optional_move_base;
-  };
+// This class manages conditionally having a trivial copy assignment operator
+template <class T, bool = IS_TRIVIALLY_COPY_ASSIGNABLE(T) &&
+                          IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T) &&
+                          IS_TRIVIALLY_DESTRUCTIBLE(T)>
+struct optional_copy_assign_base : optional_move_base<T> {
+  using optional_move_base<T>::optional_move_base;
+};
 
-  template <class T>
-  struct optional_copy_assign_base<T, false> : optional_move_base<T> {
-    using optional_move_base<T>::optional_move_base;
+template <class T>
+struct optional_copy_assign_base<T, false> : optional_move_base<T> {
+  using optional_move_base<T>::optional_move_base;
 
-    optional_copy_assign_base() = default;
-    optional_copy_assign_base(const optional_copy_assign_base &rhs) = default;
+  optional_copy_assign_base() = default;
+  optional_copy_assign_base(const optional_copy_assign_base &rhs) = default;
 
-    optional_copy_assign_base(optional_copy_assign_base &&rhs) = default;
-    optional_copy_assign_base &operator=(const optional_copy_assign_base &rhs) {
-      this->assign(rhs);
-      return *this;
-    }
-    optional_copy_assign_base &
-    operator=(optional_copy_assign_base &&rhs) = default;
-  };
+  optional_copy_assign_base(optional_copy_assign_base &&rhs) = default;
+  optional_copy_assign_base &operator=(const optional_copy_assign_base &rhs) {
+    this->assign(rhs);
+    return *this;
+  }
+  optional_copy_assign_base &
+  operator=(optional_copy_assign_base &&rhs) = default;
+};
 
 // This class manages conditionally having a trivial move assignment operator
 // Unfortunately there's no way to achieve this in GCC < 5 AFAIK, since it
@@ -468,1192 +465,2018 @@
 // to make do with a non-trivial move assignment operator even if T is trivially
 // move assignable
 #ifndef TL_OPTIONAL_GCC49
-  template <class T, bool = std::is_trivially_destructible<T>::value
-                         &&std::is_trivially_move_constructible<T>::value
-                             &&std::is_trivially_move_assignable<T>::value>
-  struct optional_move_assign_base : optional_copy_assign_base<T> {
-    using optional_copy_assign_base<T>::optional_copy_assign_base;
-  };
+template <class T, bool = std::is_trivially_destructible<T>::value
+                       &&std::is_trivially_move_constructible<T>::value
+                           &&std::is_trivially_move_assignable<T>::value>
+struct optional_move_assign_base : optional_copy_assign_base<T> {
+  using optional_copy_assign_base<T>::optional_copy_assign_base;
+};
 #else
-  template <class T, bool = false> struct optional_move_assign_base;
+template <class T, bool = false> struct optional_move_assign_base;
 #endif
 
-  template <class T>
-  struct optional_move_assign_base<T, false> : optional_copy_assign_base<T> {
-    using optional_copy_assign_base<T>::optional_copy_assign_base;
+template <class T>
+struct optional_move_assign_base<T, false> : optional_copy_assign_base<T> {
+  using optional_copy_assign_base<T>::optional_copy_assign_base;
 
-    optional_move_assign_base() = default;
-    optional_move_assign_base(const optional_move_assign_base &rhs) = default;
+  optional_move_assign_base() = default;
+  optional_move_assign_base(const optional_move_assign_base &rhs) = default;
 
-    optional_move_assign_base(optional_move_assign_base &&rhs) = default;
+  optional_move_assign_base(optional_move_assign_base &&rhs) = default;
 
-    optional_move_assign_base &
-    operator=(const optional_move_assign_base &rhs) = default;
+  optional_move_assign_base &
+  operator=(const optional_move_assign_base &rhs) = default;
 
-    optional_move_assign_base &
-    operator=(optional_move_assign_base &&rhs) noexcept(
-        std::is_nothrow_move_constructible<T>::value
-            &&std::is_nothrow_move_assignable<T>::value) {
-      this->assign(std::move(rhs));
-      return *this;
-    }
-  };
+  optional_move_assign_base &
+  operator=(optional_move_assign_base &&rhs) noexcept(
+      std::is_nothrow_move_constructible<T>::value
+          &&std::is_nothrow_move_assignable<T>::value) {
+    this->assign(std::move(rhs));
+    return *this;
+  }
+};
 
-  // optional_delete_ctor_base will conditionally delete copy and move
-  // constructors depending on whether T is copy/move constructible
-  template <class T, bool EnableCopy = std::is_copy_constructible<T>::value,
-            bool EnableMove = std::is_move_constructible<T>::value>
-  struct optional_delete_ctor_base {
-    optional_delete_ctor_base() = default;
-    optional_delete_ctor_base(const optional_delete_ctor_base &) = default;
-    optional_delete_ctor_base(optional_delete_ctor_base &&) noexcept = default;
-    optional_delete_ctor_base &
-    operator=(const optional_delete_ctor_base &) = default;
-    optional_delete_ctor_base &
-    operator=(optional_delete_ctor_base &&) noexcept = default;
-  };
+// optional_delete_ctor_base will conditionally delete copy and move
+// constructors depending on whether T is copy/move constructible
+template <class T, bool EnableCopy = std::is_copy_constructible<T>::value,
+          bool EnableMove = std::is_move_constructible<T>::value>
+struct optional_delete_ctor_base {
+  optional_delete_ctor_base() = default;
+  optional_delete_ctor_base(const optional_delete_ctor_base &) = default;
+  optional_delete_ctor_base(optional_delete_ctor_base &&) noexcept = default;
+  optional_delete_ctor_base &
+  operator=(const optional_delete_ctor_base &) = default;
+  optional_delete_ctor_base &
+  operator=(optional_delete_ctor_base &&) noexcept = default;
+};
 
-  template <class T> struct optional_delete_ctor_base<T, true, false> {
-    optional_delete_ctor_base() = default;
-    optional_delete_ctor_base(const optional_delete_ctor_base &) = default;
-    optional_delete_ctor_base(optional_delete_ctor_base &&) noexcept = delete;
-    optional_delete_ctor_base &
-    operator=(const optional_delete_ctor_base &) = default;
-    optional_delete_ctor_base &
-    operator=(optional_delete_ctor_base &&) noexcept = default;
-  };
+template <class T> struct optional_delete_ctor_base<T, true, false> {
+  optional_delete_ctor_base() = default;
+  optional_delete_ctor_base(const optional_delete_ctor_base &) = default;
+  optional_delete_ctor_base(optional_delete_ctor_base &&) noexcept = delete;
+  optional_delete_ctor_base &
+  operator=(const optional_delete_ctor_base &) = default;
+  optional_delete_ctor_base &
+  operator=(optional_delete_ctor_base &&) noexcept = default;
+};
 
-  template <class T> struct optional_delete_ctor_base<T, false, true> {
-    optional_delete_ctor_base() = default;
-    optional_delete_ctor_base(const optional_delete_ctor_base &) = delete;
-    optional_delete_ctor_base(optional_delete_ctor_base &&) noexcept = default;
-    optional_delete_ctor_base &
-    operator=(const optional_delete_ctor_base &) = default;
-    optional_delete_ctor_base &
-    operator=(optional_delete_ctor_base &&) noexcept = default;
-  };
+template <class T> struct optional_delete_ctor_base<T, false, true> {
+  optional_delete_ctor_base() = default;
+  optional_delete_ctor_base(const optional_delete_ctor_base &) = delete;
+  optional_delete_ctor_base(optional_delete_ctor_base &&) noexcept = default;
+  optional_delete_ctor_base &
+  operator=(const optional_delete_ctor_base &) = default;
+  optional_delete_ctor_base &
+  operator=(optional_delete_ctor_base &&) noexcept = default;
+};
 
-  template <class T> struct optional_delete_ctor_base<T, false, false> {
-    optional_delete_ctor_base() = default;
-    optional_delete_ctor_base(const optional_delete_ctor_base &) = delete;
-    optional_delete_ctor_base(optional_delete_ctor_base &&) noexcept = delete;
-    optional_delete_ctor_base &
-    operator=(const optional_delete_ctor_base &) = default;
-    optional_delete_ctor_base &
-    operator=(optional_delete_ctor_base &&) noexcept = default;
-  };
+template <class T> struct optional_delete_ctor_base<T, false, false> {
+  optional_delete_ctor_base() = default;
+  optional_delete_ctor_base(const optional_delete_ctor_base &) = delete;
+  optional_delete_ctor_base(optional_delete_ctor_base &&) noexcept = delete;
+  optional_delete_ctor_base &
+  operator=(const optional_delete_ctor_base &) = default;
+  optional_delete_ctor_base &
+  operator=(optional_delete_ctor_base &&) noexcept = default;
+};
 
-  // optional_delete_assign_base will conditionally delete copy and move
-  // constructors depending on whether T is copy/move constructible + assignable
-  template <class T,
-            bool EnableCopy = (std::is_copy_constructible<T>::value &&
-                               std::is_copy_assignable<T>::value),
-            bool EnableMove = (std::is_move_constructible<T>::value &&
-                               std::is_move_assignable<T>::value)>
-  struct optional_delete_assign_base {
-    optional_delete_assign_base() = default;
-    optional_delete_assign_base(const optional_delete_assign_base &) = default;
-    optional_delete_assign_base(optional_delete_assign_base &&) noexcept =
-        default;
-    optional_delete_assign_base &
-    operator=(const optional_delete_assign_base &) = default;
-    optional_delete_assign_base &
-    operator=(optional_delete_assign_base &&) noexcept = default;
-  };
+// optional_delete_assign_base will conditionally delete copy and move
+// constructors depending on whether T is copy/move constructible + assignable
+template <class T,
+          bool EnableCopy = (std::is_copy_constructible<T>::value &&
+                             std::is_copy_assignable<T>::value),
+          bool EnableMove = (std::is_move_constructible<T>::value &&
+                             std::is_move_assignable<T>::value)>
+struct optional_delete_assign_base {
+  optional_delete_assign_base() = default;
+  optional_delete_assign_base(const optional_delete_assign_base &) = default;
+  optional_delete_assign_base(optional_delete_assign_base &&) noexcept =
+      default;
+  optional_delete_assign_base &
+  operator=(const optional_delete_assign_base &) = default;
+  optional_delete_assign_base &
+  operator=(optional_delete_assign_base &&) noexcept = default;
+};
 
-  template <class T> struct optional_delete_assign_base<T, true, false> {
-    optional_delete_assign_base() = default;
-    optional_delete_assign_base(const optional_delete_assign_base &) = default;
-    optional_delete_assign_base(optional_delete_assign_base &&) noexcept =
-        default;
-    optional_delete_assign_base &
-    operator=(const optional_delete_assign_base &) = default;
-    optional_delete_assign_base &
-    operator=(optional_delete_assign_base &&) noexcept = delete;
-  };
+template <class T> struct optional_delete_assign_base<T, true, false> {
+  optional_delete_assign_base() = default;
+  optional_delete_assign_base(const optional_delete_assign_base &) = default;
+  optional_delete_assign_base(optional_delete_assign_base &&) noexcept =
+      default;
+  optional_delete_assign_base &
+  operator=(const optional_delete_assign_base &) = default;
+  optional_delete_assign_base &
+  operator=(optional_delete_assign_base &&) noexcept = delete;
+};
 
-  template <class T> struct optional_delete_assign_base<T, false, true> {
-    optional_delete_assign_base() = default;
-    optional_delete_assign_base(const optional_delete_assign_base &) = default;
-    optional_delete_assign_base(optional_delete_assign_base &&) noexcept =
-        default;
-    optional_delete_assign_base &
-    operator=(const optional_delete_assign_base &) = delete;
-    optional_delete_assign_base &
-    operator=(optional_delete_assign_base &&) noexcept = default;
-  };
+template <class T> struct optional_delete_assign_base<T, false, true> {
+  optional_delete_assign_base() = default;
+  optional_delete_assign_base(const optional_delete_assign_base &) = default;
+  optional_delete_assign_base(optional_delete_assign_base &&) noexcept =
+      default;
+  optional_delete_assign_base &
+  operator=(const optional_delete_assign_base &) = delete;
+  optional_delete_assign_base &
+  operator=(optional_delete_assign_base &&) noexcept = default;
+};
 
-  template <class T> struct optional_delete_assign_base<T, false, false> {
-    optional_delete_assign_base() = default;
-    optional_delete_assign_base(const optional_delete_assign_base &) = default;
-    optional_delete_assign_base(optional_delete_assign_base &&) noexcept =
-        default;
-    optional_delete_assign_base &
-    operator=(const optional_delete_assign_base &) = delete;
-    optional_delete_assign_base &
-    operator=(optional_delete_assign_base &&) noexcept = delete;
-  };
+template <class T> struct optional_delete_assign_base<T, false, false> {
+  optional_delete_assign_base() = default;
+  optional_delete_assign_base(const optional_delete_assign_base &) = default;
+  optional_delete_assign_base(optional_delete_assign_base &&) noexcept =
+      default;
+  optional_delete_assign_base &
+  operator=(const optional_delete_assign_base &) = delete;
+  optional_delete_assign_base &
+  operator=(optional_delete_assign_base &&) noexcept = delete;
+};
 
-  } // namespace detail
+} // namespace detail
 
-  /// \brief A tag type to represent an empty optional
-  struct nullopt_t {
-    struct do_not_use {};
-    constexpr explicit nullopt_t(do_not_use, do_not_use) noexcept {}
-  };
-  /// \brief Represents an empty optional
-  /// \synopsis static constexpr nullopt_t nullopt;
-  ///
-  /// *Examples*:
-  /// ```
-  /// tl::optional<int> a = tl::nullopt;
-  /// void foo (tl::optional<int>);
-  /// foo(tl::nullopt); //pass an empty optional
-  /// ```
-  static constexpr nullopt_t nullopt{nullopt_t::do_not_use{},
-                                     nullopt_t::do_not_use{}};
+/// \brief A tag type to represent an empty optional
+struct nullopt_t {
+  struct do_not_use {};
+  constexpr explicit nullopt_t(do_not_use, do_not_use) noexcept {}
+};
+/// \brief Represents an empty optional
+/// \synopsis static constexpr nullopt_t nullopt;
+///
+/// *Examples*:
+/// ```
+/// tl::optional<int> a = tl::nullopt;
+/// void foo (tl::optional<int>);
+/// foo(tl::nullopt); //pass an empty optional
+/// ```
+static constexpr nullopt_t nullopt{nullopt_t::do_not_use{},
+                                   nullopt_t::do_not_use{}};
 
-  class bad_optional_access : public std::exception {
-  public:
-    bad_optional_access() = default;
-    const char *what() const noexcept { return "Optional has no value"; }
-  };
+class bad_optional_access : public std::exception {
+public:
+  bad_optional_access() = default;
+  const char *what() const noexcept { return "Optional has no value"; }
+};
 
-  /// An optional object is an object that contains the storage for another
-  /// object and manages the lifetime of this contained object, if any. The
-  /// contained object may be initialized after the optional object has been
-  /// initialized, and may be destroyed before the optional object has been
-  /// destroyed. The initialization state of the contained object is tracked by
-  /// the optional object.
-  template <class T>
-  class optional : private detail::optional_move_assign_base<T>,
-                   private detail::optional_delete_ctor_base<T>,
-                   private detail::optional_delete_assign_base<T> {
-    using base = detail::optional_move_assign_base<T>;
+/// An optional object is an object that contains the storage for another
+/// object and manages the lifetime of this contained object, if any. The
+/// contained object may be initialized after the optional object has been
+/// initialized, and may be destroyed before the optional object has been
+/// destroyed. The initialization state of the contained object is tracked by
+/// the optional object.
+template <class T>
+class optional : private detail::optional_move_assign_base<T>,
+                 private detail::optional_delete_ctor_base<T>,
+                 private detail::optional_delete_assign_base<T> {
+  using base = detail::optional_move_assign_base<T>;
 
-    static_assert(
-        !std::is_reference<T>::value,
-        "instantiation of optional with a reference type is ill-formed");
-    static_assert(!std::is_same<T, in_place_t>::value,
-                  "instantiation of optional with in_place_t is ill-formed");
-    static_assert(!std::is_same<detail::decay_t<T>, nullopt_t>::value,
-                  "instantiation of optional with nullopt_t is ill-formed");
+  static_assert(!std::is_same<T, in_place_t>::value,
+                "instantiation of optional with in_place_t is ill-formed");
+  static_assert(!std::is_same<detail::decay_t<T>, nullopt_t>::value,
+                "instantiation of optional with nullopt_t is ill-formed");
 
-  public:
+public:
 // The different versions for C++14 and 11 are needed because deduced return
 // types are not SFINAE-safe. This provides better support for things like
 // generic lambdas. C.f.
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0826r0.html
 #if defined(TL_OPTIONAL_CXX14) && !defined(TL_OPTIONAL_GCC49) &&               \
     !defined(TL_OPTIONAL_GCC54)
-    /// \group and_then
-    /// Carries out some operation which returns an optional on the stored
-    /// object if there is one. \requires `std::invoke(std::forward<F>(f),
-    /// value())` returns a `std::optional<U>` for some `U`. \returns Let `U` be
-    /// the result of `std::invoke(std::forward<F>(f), value())`. Returns a
-    /// `std::optional<U>`. The return value is empty if `*this` is empty,
-    /// otherwise the return value of `std::invoke(std::forward<F>(f), value())`
-    /// is returned.
-    /// \group and_then
-    /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &;
-    template <class F> TL_OPTIONAL_11_CONSTEXPR auto and_then(F &&f) & {
-      using result = detail::invoke_result_t<F, T &>;
-      static_assert(detail::is_optional<result>::value,
-                    "F must return an optional");
+  /// \group and_then
+  /// Carries out some operation which returns an optional on the stored
+  /// object if there is one. \requires `std::invoke(std::forward<F>(f),
+  /// value())` returns a `std::optional<U>` for some `U`. \returns Let `U` be
+  /// the result of `std::invoke(std::forward<F>(f), value())`. Returns a
+  /// `std::optional<U>`. The return value is empty if `*this` is empty,
+  /// otherwise the return value of `std::invoke(std::forward<F>(f), value())`
+  /// is returned.
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &;
+  template <class F> TL_OPTIONAL_11_CONSTEXPR auto and_then(F &&f) & {
+    using result = detail::invoke_result_t<F, T &>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
 
-      return has_value() ? detail::invoke(std::forward<F>(f), **this)
-                         : result(nullopt);
-    }
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : result(nullopt);
+  }
 
-    /// \group and_then
-    /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &&;
-    template <class F> TL_OPTIONAL_11_CONSTEXPR auto and_then(F &&f) && {
-      using result = detail::invoke_result_t<F, T &&>;
-      static_assert(detail::is_optional<result>::value,
-                    "F must return an optional");
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &&;
+  template <class F> TL_OPTIONAL_11_CONSTEXPR auto and_then(F &&f) && {
+    using result = detail::invoke_result_t<F, T &&>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
 
-      return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
-                         : result(nullopt);
-    }
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : result(nullopt);
+  }
 
-    /// \group and_then
-    /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &;
-    template <class F> constexpr auto and_then(F &&f) const & {
-      using result = detail::invoke_result_t<F, const T &>;
-      static_assert(detail::is_optional<result>::value,
-                    "F must return an optional");
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &;
+  template <class F> constexpr auto and_then(F &&f) const & {
+    using result = detail::invoke_result_t<F, const T &>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
 
-      return has_value() ? detail::invoke(std::forward<F>(f), **this)
-                         : result(nullopt);
-    }
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : result(nullopt);
+  }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-    /// \group and_then
-    /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &&;
-    template <class F> constexpr auto and_then(F &&f) const && {
-      using result = detail::invoke_result_t<F, const T &&>;
-      static_assert(detail::is_optional<result>::value,
-                    "F must return an optional");
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &&;
+  template <class F> constexpr auto and_then(F &&f) const && {
+    using result = detail::invoke_result_t<F, const T &&>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
 
-      return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
-                         : result(nullopt);
-    }
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : result(nullopt);
+  }
 #endif
 #else
-    /// \group and_then
-    /// Carries out some operation which returns an optional on the stored
-    /// object if there is one. \requires `std::invoke(std::forward<F>(f),
-    /// value())` returns a `std::optional<U>` for some `U`. \returns Let `U` be
-    /// the result of `std::invoke(std::forward<F>(f), value())`. Returns a
-    /// `std::optional<U>`. The return value is empty if `*this` is empty,
-    /// otherwise the return value of `std::invoke(std::forward<F>(f), value())`
-    /// is returned.
-    /// \group and_then
-    /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &;
-    template <class F>
-    TL_OPTIONAL_11_CONSTEXPR detail::invoke_result_t<F, T &> and_then(F &&f) & {
-      using result = detail::invoke_result_t<F, T &>;
-      static_assert(detail::is_optional<result>::value,
-                    "F must return an optional");
+  /// \group and_then
+  /// Carries out some operation which returns an optional on the stored
+  /// object if there is one. \requires `std::invoke(std::forward<F>(f),
+  /// value())` returns a `std::optional<U>` for some `U`. \returns Let `U` be
+  /// the result of `std::invoke(std::forward<F>(f), value())`. Returns a
+  /// `std::optional<U>`. The return value is empty if `*this` is empty,
+  /// otherwise the return value of `std::invoke(std::forward<F>(f), value())`
+  /// is returned.
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &;
+  template <class F>
+  TL_OPTIONAL_11_CONSTEXPR detail::invoke_result_t<F, T &> and_then(F &&f) & {
+    using result = detail::invoke_result_t<F, T &>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
 
-      return has_value() ? detail::invoke(std::forward<F>(f), **this)
-                         : result(nullopt);
-    }
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : result(nullopt);
+  }
 
-    /// \group and_then
-    /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &&;
-    template <class F>
-    TL_OPTIONAL_11_CONSTEXPR detail::invoke_result_t<F, T &&>
-    and_then(F &&f) && {
-      using result = detail::invoke_result_t<F, T &&>;
-      static_assert(detail::is_optional<result>::value,
-                    "F must return an optional");
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &&;
+  template <class F>
+  TL_OPTIONAL_11_CONSTEXPR detail::invoke_result_t<F, T &&> and_then(F &&f) && {
+    using result = detail::invoke_result_t<F, T &&>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
 
-      return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
-                         : result(nullopt);
-    }
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : result(nullopt);
+  }
 
-    /// \group and_then
-    /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &;
-    template <class F>
-    constexpr detail::invoke_result_t<F, const T &> and_then(F &&f) const & {
-      using result = detail::invoke_result_t<F, const T &>;
-      static_assert(detail::is_optional<result>::value,
-                    "F must return an optional");
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &;
+  template <class F>
+  constexpr detail::invoke_result_t<F, const T &> and_then(F &&f) const & {
+    using result = detail::invoke_result_t<F, const T &>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
 
-      return has_value() ? detail::invoke(std::forward<F>(f), **this)
-                         : result(nullopt);
-    }
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : result(nullopt);
+  }
 
 #ifndef TL_OPTIONAL_NO_CONSTRR
-    /// \group and_then
-    /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &&;
-    template <class F>
-    constexpr detail::invoke_result_t<F, const T &&> and_then(F &&f) const && {
-      using result = detail::invoke_result_t<F, const T &&>;
-      static_assert(detail::is_optional<result>::value,
-                    "F must return an optional");
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &&;
+  template <class F>
+  constexpr detail::invoke_result_t<F, const T &&> and_then(F &&f) const && {
+    using result = detail::invoke_result_t<F, const T &&>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
 
-      return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
-                         : result(nullopt);
-    }
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : result(nullopt);
+  }
 #endif
 #endif
 
 #if defined(TL_OPTIONAL_CXX14) && !defined(TL_OPTIONAL_GCC49) &&               \
     !defined(TL_OPTIONAL_GCC54)
-    /// \brief Carries out some operation on the stored object if there is one.
-    /// \returns Let `U` be the result of `std::invoke(std::forward<F>(f),
-    /// value())`. Returns a `std::optional<U>`. The return value is empty if
-    /// `*this` is empty, otherwise an `optional<U>` is constructed from the
-    /// return value of `std::invoke(std::forward<F>(f), value())` and is
-    /// returned.
-    ///
-    /// \group map
-    /// \synopsis template <class F> constexpr auto map(F &&f) &;
-    template <class F> TL_OPTIONAL_11_CONSTEXPR auto map(F &&f) & {
-      return map_impl(*this, std::forward<F>(f));
-    }
-
-    /// \group map
-    /// \synopsis template <class F> constexpr auto map(F &&f) &&;
-    template <class F> TL_OPTIONAL_11_CONSTEXPR auto map(F &&f) && {
-      return map_impl(std::move(*this), std::forward<F>(f));
-    }
-
-    /// \group map
-    /// \synopsis template <class F> constexpr auto map(F &&f) const&;
-    template <class F> constexpr auto map(F &&f) const & {
-      return map_impl(*this, std::forward<F>(f));
-    }
-
-    /// \group map
-    /// \synopsis template <class F> constexpr auto map(F &&f) const&&;
-    template <class F> constexpr auto map(F &&f) const && {
-      return map_impl(std::move(*this), std::forward<F>(f));
-    }
-#else
-    /// \brief Carries out some operation on the stored object if there is one.
-    /// \returns Let `U` be the result of `std::invoke(std::forward<F>(f),
-    /// value())`. Returns a `std::optional<U>`. The return value is empty if
-    /// `*this` is empty, otherwise an `optional<U>` is constructed from the
-    /// return value of `std::invoke(std::forward<F>(f), value())` and is
-    /// returned.
-    ///
-    /// \group map
-    /// \synopsis template <class F> auto map(F &&f) &;
-    template <class F>
-    TL_OPTIONAL_11_CONSTEXPR decltype(map_impl(std::declval<optional &>(),
-                                               std::declval<F &&>()))
-    map(F &&f) & {
-      return map_impl(*this, std::forward<F>(f));
-    }
-
-    /// \group map
-    /// \synopsis template <class F> auto map(F &&f) &&;
-    template <class F>
-    TL_OPTIONAL_11_CONSTEXPR decltype(map_impl(std::declval<optional &&>(),
-                                               std::declval<F &&>()))
-    map(F &&f) && {
-      return map_impl(std::move(*this), std::forward<F>(f));
-    }
-
-    /// \group map
-    /// \synopsis template <class F> auto map(F &&f) const&;
-    template <class F>
-    constexpr decltype(map_impl(std::declval<const optional &>(),
-                                std::declval<F &&>()))
-    map(F &&f) const & {
-      return map_impl(*this, std::forward<F>(f));
-    }
-
-#ifndef TL_OPTIONAL_NO_CONSTRR
-    /// \group map
-    /// \synopsis template <class F> auto map(F &&f) const&&;
-    template <class F>
-    constexpr decltype(map_impl(std::declval<const optional &&>(),
-                                std::declval<F &&>()))
-    map(F &&f) const && {
-      return map_impl(std::move(*this), std::forward<F>(f));
-    }
-#endif
-#endif
-
-    /// \brief Calls `f` if the optional is empty
-    /// \requires `std::invoke_result_t<F>` must be void or convertible to
-    /// `optional<T>`. \effects If `*this` has a value, returns `*this`.
-    /// Otherwise, if `f` returns `void`, calls `std::forward<F>(f)` and returns
-    /// `std::nullopt`. Otherwise, returns `std::forward<F>(f)()`.
-    ///
-    /// \group or_else
-    /// \synopsis template <class F> optional<T> or_else (F &&f) &;
-    template <class F, detail::enable_if_ret_void<F> * = nullptr>
-    optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) & {
-      if (has_value())
-        return *this;
-
-      std::forward<F>(f)();
-      return nullopt;
-    }
-
-    /// \exclude
-    template <class F, detail::disable_if_ret_void<F> * = nullptr>
-    optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) & {
-      return has_value() ? *this : std::forward<F>(f)();
-    }
-
-    /// \group or_else
-    /// \synopsis template <class F> optional<T> or_else (F &&f) &&;
-    template <class F, detail::enable_if_ret_void<F> * = nullptr>
-    optional<T> or_else(F &&f) && {
-      if (has_value())
-        return std::move(*this);
-
-      std::forward<F>(f)();
-      return nullopt;
-    }
-
-    /// \exclude
-    template <class F, detail::disable_if_ret_void<F> * = nullptr>
-    optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) && {
-      return has_value() ? std::move(*this) : std::forward<F>(f)();
-    }
-
-    /// \group or_else
-    /// \synopsis template <class F> optional<T> or_else (F &&f) const &;
-    template <class F, detail::enable_if_ret_void<F> * = nullptr>
-    optional<T> or_else(F &&f) const & {
-      if (has_value())
-        return *this;
-
-      std::forward<F>(f)();
-      return nullopt;
-    }
-
-    /// \exclude
-    template <class F, detail::disable_if_ret_void<F> * = nullptr>
-    optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) const & {
-      return has_value() ? *this : std::forward<F>(f)();
-    }
-
-#ifndef TL_OPTIONAL_NO_CONSTRR
-    /// \exclude
-    template <class F, detail::enable_if_ret_void<F> * = nullptr>
-    optional<T> or_else(F &&f) const && {
-      if (has_value())
-        return std::move(*this);
-
-      std::forward<F>(f)();
-      return nullopt;
-    }
-
-    /// \exclude
-    template <class F, detail::disable_if_ret_void<F> * = nullptr>
-    optional<T> or_else(F &&f) const && {
-      return has_value() ? std::move(*this) : std::forward<F>(f)();
-    }
-#endif
-
-    /// \brief Maps the stored value with `f` if there is one, otherwise returns
-    /// `u`.
-    ///
-    /// \details If there is a value stored, then `f` is called with `**this`
-    /// and the value is returned. Otherwise `u` is returned.
-    ///
-    /// \group map_or
-    template <class F, class U> U map_or(F &&f, U &&u) & {
-      return has_value() ? detail::invoke(std::forward<F>(f), **this)
-                         : std::forward<U>(u);
-    }
-
-    /// \group map_or
-    template <class F, class U> U map_or(F &&f, U &&u) && {
-      return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
-                         : std::forward<U>(u);
-    }
-
-    /// \group map_or
-    template <class F, class U> U map_or(F &&f, U &&u) const & {
-      return has_value() ? detail::invoke(std::forward<F>(f), **this)
-                         : std::forward<U>(u);
-    }
-
-#ifndef TL_OPTIONAL_NO_CONSTRR
-    /// \group map_or
-    template <class F, class U> U map_or(F &&f, U &&u) const && {
-      return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
-                         : std::forward<U>(u);
-    }
-#endif
-
-    /// \brief Maps the stored value with `f` if there is one, otherwise calls
-    /// `u` and returns the result.
-    ///
-    /// \details If there is a value stored, then `f` is
-    /// called with `**this` and the value is returned. Otherwise
-    /// `std::forward<U>(u)()` is returned.
-    ///
-    /// \group map_or_else
-    /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u) &;
-    template <class F, class U>
-    detail::invoke_result_t<U> map_or_else(F &&f, U &&u) & {
-      return has_value() ? detail::invoke(std::forward<F>(f), **this)
-                         : std::forward<U>(u)();
-    }
-
-    /// \group map_or_else
-    /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u)
-    /// &&;
-    template <class F, class U>
-    detail::invoke_result_t<U> map_or_else(F &&f, U &&u) && {
-      return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
-                         : std::forward<U>(u)();
-    }
-
-    /// \group map_or_else
-    /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u)
-    /// const &;
-    template <class F, class U>
-    detail::invoke_result_t<U> map_or_else(F &&f, U &&u) const & {
-      return has_value() ? detail::invoke(std::forward<F>(f), **this)
-                         : std::forward<U>(u)();
-    }
-
-#ifndef TL_OPTIONAL_NO_CONSTRR
-    /// \group map_or_else
-    /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u)
-    /// const &&;
-    template <class F, class U>
-    detail::invoke_result_t<U> map_or_else(F &&f, U &&u) const && {
-      return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
-                         : std::forward<U>(u)();
-    }
-#endif
-
-    /// \returns `u` if `*this` has a value, otherwise an empty optional.
-    template <class U>
-    constexpr optional<typename std::decay<U>::type> conjunction(U &&u) const {
-      using result = optional<detail::decay_t<U>>;
-      return has_value() ? result{u} : result{nullopt};
-    }
-
-    /// \returns `rhs` if `*this` is empty, otherwise the current value.
-    /// \group disjunction
-    TL_OPTIONAL_11_CONSTEXPR optional disjunction(const optional &rhs) & {
-      return has_value() ? *this : rhs;
-    }
-
-    /// \group disjunction
-    constexpr optional disjunction(const optional &rhs) const & {
-      return has_value() ? *this : rhs;
-    }
-
-    /// \group disjunction
-    TL_OPTIONAL_11_CONSTEXPR optional disjunction(const optional &rhs) && {
-      return has_value() ? std::move(*this) : rhs;
-    }
-
-#ifndef TL_OPTIONAL_NO_CONSTRR
-    /// \group disjunction
-    constexpr optional disjunction(const optional &rhs) const && {
-      return has_value() ? std::move(*this) : rhs;
-    }
-#endif
-
-    /// \group disjunction
-    TL_OPTIONAL_11_CONSTEXPR optional disjunction(optional &&rhs) & {
-      return has_value() ? *this : std::move(rhs);
-    }
-
-    /// \group disjunction
-    constexpr optional disjunction(optional &&rhs) const & {
-      return has_value() ? *this : std::move(rhs);
-    }
-
-    /// \group disjunction
-    TL_OPTIONAL_11_CONSTEXPR optional disjunction(optional &&rhs) && {
-      return has_value() ? std::move(*this) : std::move(rhs);
-    }
-
-#ifndef TL_OPTIONAL_NO_CONSTRR
-    /// \group disjunction
-    constexpr optional disjunction(optional &&rhs) const && {
-      return has_value() ? std::move(*this) : std::move(rhs);
-    }
-#endif
-
-    /// Takes the value out of the optional, leaving it empty
-    /// \group take
-    optional take() & {
-      optional ret = *this;
-      reset();
-      return ret;
-    }
-
-    /// \group take
-    optional take() const & {
-      optional ret = *this;
-      reset();
-      return ret;
-    }
-
-    /// \group take
-    optional take() && {
-      optional ret = std::move(*this);
-      reset();
-      return ret;
-    }
-
-#ifndef TL_OPTIONAL_NO_CONSTRR
-    /// \group take
-    optional take() const && {
-      optional ret = std::move(*this);
-      reset();
-      return ret;
-    }
-#endif
-
-    using value_type = T;
-
-    /// Constructs an optional that does not contain a value.
-    /// \group ctor_empty
-    constexpr optional() noexcept = default;
-
-    /// \group ctor_empty
-    constexpr optional(nullopt_t) noexcept {}
-
-    /// Copy constructor
-    ///
-    /// If `rhs` contains a value, the stored value is direct-initialized with
-    /// it. Otherwise, the constructed optional is empty.
-    TL_OPTIONAL_11_CONSTEXPR optional(const optional &rhs) = default;
-
-    /// Move constructor
-    ///
-    /// If `rhs` contains a value, the stored value is direct-initialized with
-    /// it. Otherwise, the constructed optional is empty.
-    TL_OPTIONAL_11_CONSTEXPR optional(optional &&rhs) = default;
-
-    /// Constructs the stored value in-place using the given arguments.
-    /// \group in_place
-    /// \synopsis template <class... Args> constexpr explicit
-    /// optional(in_place_t, Args&&... args);
-    template <class... Args>
-    constexpr explicit optional(
-        detail::enable_if_t<std::is_constructible<T, Args...>::value,
-                            in_place_t>,
-        Args &&... args)
-        : base(in_place, std::forward<Args>(args)...) {}
-
-    /// \group in_place
-    /// \synopsis template <class U, class... Args>\nconstexpr explicit
-    /// optional(in_place_t, std::initializer_list<U>&, Args&&... args);
-    template <class U, class... Args>
-    TL_OPTIONAL_11_CONSTEXPR explicit optional(
-        detail::enable_if_t<std::is_constructible<T, std::initializer_list<U> &,
-                                                  Args &&...>::value,
-                            in_place_t>,
-        std::initializer_list<U> il, Args &&... args) {
-      this->construct(il, std::forward<Args>(args)...);
-    }
-
-    /// Constructs the stored value with `u`.
-    /// \synopsis template <class U=T> constexpr optional(U &&u);
-    template <
-        class U = T,
-        detail::enable_if_t<std::is_convertible<U &&, T>::value> * = nullptr,
-        detail::enable_forward_value<T, U> * = nullptr>
-    constexpr optional(U &&u) : base(in_place, std::forward<U>(u)) {}
-
-    /// \exclude
-    template <
-        class U = T,
-        detail::enable_if_t<!std::is_convertible<U &&, T>::value> * = nullptr,
-        detail::enable_forward_value<T, U> * = nullptr>
-    constexpr explicit optional(U &&u) : base(in_place, std::forward<U>(u)) {}
-
-    /// Converting copy constructor.
-    /// \synopsis template <class U> optional(const optional<U> &rhs);
-    template <class U, detail::enable_from_other<T, U, const U &> * = nullptr,
-              detail::enable_if_t<std::is_convertible<const U &, T>::value> * =
-                  nullptr>
-    optional(const optional<U> &rhs) {
-      this->construct(*rhs);
-    }
-
-    /// \exclude
-    template <class U, detail::enable_from_other<T, U, const U &> * = nullptr,
-              detail::enable_if_t<!std::is_convertible<const U &, T>::value> * =
-                  nullptr>
-    explicit optional(const optional<U> &rhs) {
-      this->construct(*rhs);
-    }
-
-    /// Converting move constructor.
-    /// \synopsis template <class U> optional(optional<U> &&rhs);
-    template <
-        class U, detail::enable_from_other<T, U, U &&> * = nullptr,
-        detail::enable_if_t<std::is_convertible<U &&, T>::value> * = nullptr>
-    optional(optional<U> &&rhs) {
-      this->construct(std::move(*rhs));
-    }
-
-    /// \exclude
-    template <
-        class U, detail::enable_from_other<T, U, U &&> * = nullptr,
-        detail::enable_if_t<!std::is_convertible<U &&, T>::value> * = nullptr>
-    explicit optional(optional<U> &&rhs) {
-      this->construct(std::move(*rhs));
-    }
-
-    /// Destroys the stored value if there is one.
-    ~optional() = default;
-
-    /// Assignment to empty.
-    ///
-    /// Destroys the current value if there is one.
-    optional &operator=(nullopt_t) noexcept {
-      if (has_value()) {
-        this->m_value.~T();
-        this->m_has_value = false;
-      }
-
-      return *this;
-    }
-
-    /// Copy assignment.
-    ///
-    /// Copies the value from `rhs` if there is one. Otherwise resets the stored
-    /// value in `*this`.
-    optional &operator=(const optional &rhs) = default;
-
-    /// Move assignment.
-    ///
-    /// Moves the value from `rhs` if there is one. Otherwise resets the stored
-    /// value in `*this`.
-    optional &operator=(optional &&rhs) = default;
-
-    /// Assigns the stored value from `u`, destroying the old value if there was
-    /// one.
-    /// \synopsis optional &operator=(U &&u);
-    template <class U = T, detail::enable_assign_forward<T, U> * = nullptr>
-    optional &operator=(U &&u) {
-      if (has_value()) {
-        this->m_value = std::forward<U>(u);
-      } else {
-        this->construct(std::forward<U>(u));
-      }
-
-      return *this;
-    }
-
-    /// Converting copy assignment operator.
-    ///
-    /// Copies the value from `rhs` if there is one. Otherwise resets the stored
-    /// value in `*this`.
-    /// \synopsis optional &operator=(const optional<U> & rhs);
-    template <class U,
-              detail::enable_assign_from_other<T, U, const U &> * = nullptr>
-    optional &operator=(const optional<U> &rhs) {
-      if (has_value()) {
-        if (rhs.has_value()) {
-          this->m_value = *rhs;
-        } else {
-          this->hard_reset();
-        }
-      }
-
-      if (rhs.has_value()) {
-        this->construct(*rhs);
-      }
-
-      return *this;
-    }
-
-    // TODO check exception guarantee
-    /// Converting move assignment operator.
-    ///
-    /// Moves the value from `rhs` if there is one. Otherwise resets the stored
-    /// value in `*this`.
-    /// \synopsis optional &operator=(optional<U> && rhs);
-    template <class U, detail::enable_assign_from_other<T, U, U> * = nullptr>
-    optional &operator=(optional<U> &&rhs) {
-      if (has_value()) {
-        if (rhs.has_value()) {
-          this->m_value = std::move(*rhs);
-        } else {
-          this->hard_reset();
-        }
-      }
-
-      if (rhs.has_value()) {
-        this->construct(std::move(*rhs));
-      }
-
-      return *this;
-    }
-
-    /// Constructs the value in-place, destroying the current one if there is
-    /// one. \group emplace
-    template <class... Args> T &emplace(Args &&... args) {
-      static_assert(std::is_constructible<T, Args &&...>::value,
-                    "T must be constructible with Args");
-
-      *this = nullopt;
-      this->construct(std::forward<Args>(args)...);
-    }
-
-    /// \group emplace
-    /// \synopsis template <class U, class... Args>\nT&
-    /// emplace(std::initializer_list<U> il, Args &&... args);
-    template <class U, class... Args>
-    detail::enable_if_t<
-        std::is_constructible<T, std::initializer_list<U> &, Args &&...>::value,
-        T &>
-    emplace(std::initializer_list<U> il, Args &&... args) {
-      *this = nullopt;
-      this->construct(il, std::forward<Args>(args)...);
-    }
-
-    /// Swaps this optional with the other.
-    ///
-    /// If neither optionals have a value, nothing happens.
-    /// If both have a value, the values are swapped.
-    /// If one has a value, it is moved to the other and the movee is left
-    /// valueless.
-    void
-    swap(optional &rhs) noexcept(std::is_nothrow_move_constructible<T>::value
-                                     &&detail::is_nothrow_swappable<T>::value) {
-      if (has_value()) {
-        if (rhs.has_value()) {
-          using std::swap;
-          swap(**this, *rhs);
-        } else {
-          new (std::addressof(rhs.m_value)) T(std::move(this->m_value));
-          this->m_value.T::~T();
-        }
-      } else if (rhs.has_value()) {
-        new (std::addressof(this->m_value)) T(std::move(rhs.m_value));
-        rhs.m_value.T::~T();
-      }
-    }
-
-    /// \returns a pointer to the stored value
-    /// \requires a value is stored
-    /// \group pointer
-    /// \synopsis constexpr const T *operator->() const;
-    constexpr const T *operator->() const {
-      return std::addressof(this->m_value);
-    }
-
-    /// \group pointer
-    /// \synopsis constexpr T *operator->();
-    TL_OPTIONAL_11_CONSTEXPR T *operator->() {
-      return std::addressof(this->m_value);
-    }
-
-    /// \returns the stored value
-    /// \requires a value is stored
-    /// \group deref
-    /// \synopsis constexpr T &operator*();
-    TL_OPTIONAL_11_CONSTEXPR T &operator*() & { return this->m_value; }
-
-    /// \group deref
-    /// \synopsis constexpr const T &operator*() const;
-    constexpr const T &operator*() const & { return this->m_value; }
-
-    /// \exclude
-    TL_OPTIONAL_11_CONSTEXPR T &&operator*() && {
-      return std::move(this->m_value);
-    }
-
-#ifndef TL_OPTIONAL_NO_CONSTRR
-    /// \exclude
-    constexpr const T &&operator*() const && {
-      return std::move(this->m_value);
-    }
-#endif
-
-    /// \returns whether or not the optional has a value
-    /// \group has_value
-    constexpr bool has_value() const noexcept { return this->m_has_value; }
-
-    /// \group has_value
-    constexpr explicit operator bool() const noexcept {
-      return this->m_has_value;
-    }
-
-    /// \returns the contained value if there is one, otherwise throws
-    /// [bad_optional_access]
-    /// \group value
-    /// synopsis constexpr T &value();
-    TL_OPTIONAL_11_CONSTEXPR T &value() & {
-      if (has_value())
-        return this->m_value;
-      throw bad_optional_access();
-    }
-    /// \group value
-    /// \synopsis constexpr const T &value() const;
-    TL_OPTIONAL_11_CONSTEXPR const T &value() const & {
-      if (has_value())
-        return this->m_value;
-      throw bad_optional_access();
-    }
-    /// \exclude
-    TL_OPTIONAL_11_CONSTEXPR T &&value() && {
-      if (has_value())
-        return std::move(this->m_value);
-      throw bad_optional_access();
-    }
-
-#ifndef TL_OPTIONAL_NO_CONSTRR
-    /// \exclude
-    constexpr const T &&value() const && {
-      if (has_value())
-        return std::move(this->m_value);
-      throw bad_optional_access();
-    }
-#endif
-
-    /// \returns the stored value if there is one, otherwise returns `u`
-    /// \group value_or
-    template <class U> constexpr T value_or(U &&u) const & {
-      static_assert(std::is_copy_constructible<T>::value &&
-                        std::is_convertible<U &&, T>::value,
-                    "T must be copy constructible and convertible from U");
-      return has_value() ? **this : static_cast<T>(std::forward<U>(u));
-    }
-
-    /// \group value_or
-    template <class U> constexpr T value_or(U &&u) && {
-      static_assert(std::is_move_constructible<T>::value &&
-                        std::is_convertible<U &&, T>::value,
-                    "T must be move constructible and convertible from U");
-      return has_value() ? **this : static_cast<T>(std::forward<U>(u));
-    }
-
-    /// Destroys the stored value if one exists, making the optional empty
-    void reset() noexcept {
-      if (has_value()) {
-        this->m_value.~T();
-        this->m_has_value = false;
-      }
-    }
-  }; // namespace tl
-
-  /// \group relop
-  /// \brief Compares two optional objects
-  /// \details If both optionals contain a value, they are compared with `T`s
-  /// relational operators. Otherwise `lhs` and `rhs` are equal only if they are
-  /// both empty, and `lhs` is less than `rhs` only if `rhs` is empty and `lhs`
-  /// is not.
-  template <class T, class U>
-  inline constexpr bool operator==(const optional<T> &lhs,
-                                   const optional<U> &rhs) {
-    return lhs.has_value() == rhs.has_value() &&
-           (!lhs.has_value() || *lhs == *rhs);
-  }
-  /// \group relop
-  template <class T, class U>
-  inline constexpr bool operator!=(const optional<T> &lhs,
-                                   const optional<U> &rhs) {
-    return lhs.has_value() != rhs.has_value() ||
-           (lhs.has_value() && *lhs != *rhs);
-  }
-  /// \group relop
-  template <class T, class U>
-  inline constexpr bool operator<(const optional<T> &lhs,
-                                  const optional<U> &rhs) {
-    return rhs.has_value() && (!lhs.has_value() || *lhs < *rhs);
-  }
-  /// \group relop
-  template <class T, class U>
-  inline constexpr bool operator>(const optional<T> &lhs,
-                                  const optional<U> &rhs) {
-    return lhs.has_value() && (!rhs.has_value() || *lhs > *rhs);
-  }
-  /// \group relop
-  template <class T, class U>
-  inline constexpr bool operator<=(const optional<T> &lhs,
-                                   const optional<U> &rhs) {
-    return !lhs.has_value() || (rhs.has_value() && *lhs <= *rhs);
-  }
-  /// \group relop
-  template <class T, class U>
-  inline constexpr bool operator>=(const optional<T> &lhs,
-                                   const optional<U> &rhs) {
-    return !rhs.has_value() || (lhs.has_value() && *lhs >= *rhs);
+  /// \brief Carries out some operation on the stored object if there is one.
+  /// \returns Let `U` be the result of `std::invoke(std::forward<F>(f),
+  /// value())`. Returns a `std::optional<U>`. The return value is empty if
+  /// `*this` is empty, otherwise an `optional<U>` is constructed from the
+  /// return value of `std::invoke(std::forward<F>(f), value())` and is
+  /// returned.
+  ///
+  /// \group map
+  /// \synopsis template <class F> constexpr auto map(F &&f) &;
+  template <class F> TL_OPTIONAL_11_CONSTEXPR auto map(F &&f) & {
+    return map_impl(*this, std::forward<F>(f));
   }
 
-  /// \group relop_nullopt
-  /// \brief Compares an optional to a `nullopt`
-  /// \details Equivalent to comparing the optional to an empty optional
-  template <class T>
-  inline constexpr bool operator==(const optional<T> &lhs, nullopt_t) noexcept {
-    return !lhs.has_value();
-  }
-  /// \group relop_nullopt
-  template <class T>
-  inline constexpr bool operator==(nullopt_t, const optional<T> &rhs) noexcept {
-    return !rhs.has_value();
-  }
-  /// \group relop_nullopt
-  template <class T>
-  inline constexpr bool operator!=(const optional<T> &lhs, nullopt_t) noexcept {
-    return lhs.has_value();
-  }
-  /// \group relop_nullopt
-  template <class T>
-  inline constexpr bool operator!=(nullopt_t, const optional<T> &rhs) noexcept {
-    return rhs.has_value();
-  }
-  /// \group relop_nullopt
-  template <class T>
-  inline constexpr bool operator<(const optional<T> &, nullopt_t) noexcept {
-    return false;
-  }
-  /// \group relop_nullopt
-  template <class T>
-  inline constexpr bool operator<(nullopt_t, const optional<T> &rhs) noexcept {
-    return rhs.has_value();
-  }
-  /// \group relop_nullopt
-  template <class T>
-  inline constexpr bool operator<=(const optional<T> &lhs, nullopt_t) noexcept {
-    return !lhs.has_value();
-  }
-  /// \group relop_nullopt
-  template <class T>
-  inline constexpr bool operator<=(nullopt_t, const optional<T> &) noexcept {
-    return true;
-  }
-  /// \group relop_nullopt
-  template <class T>
-  inline constexpr bool operator>(const optional<T> &lhs, nullopt_t) noexcept {
-    return lhs.has_value();
-  }
-  /// \group relop_nullopt
-  template <class T>
-  inline constexpr bool operator>(nullopt_t, const optional<T> &) noexcept {
-    return false;
-  }
-  /// \group relop_nullopt
-  template <class T>
-  inline constexpr bool operator>=(const optional<T> &, nullopt_t) noexcept {
-    return true;
-  }
-  /// \group relop_nullopt
-  template <class T>
-  inline constexpr bool operator>=(nullopt_t, const optional<T> &rhs) noexcept {
-    return !rhs.has_value();
+  /// \group map
+  /// \synopsis template <class F> constexpr auto map(F &&f) &&;
+  template <class F> TL_OPTIONAL_11_CONSTEXPR auto map(F &&f) && {
+    return map_impl(std::move(*this), std::forward<F>(f));
   }
 
-  /// \group relop_t
-  /// \brief Compares the optional with a value.
-  /// \details If the optional has a value, it is compared with the other value
-  /// using `T`s relational operators. Otherwise, the optional is considered
-  /// less than the value.
-  template <class T, class U>
-  inline constexpr bool operator==(const optional<T> &lhs, const U &rhs) {
-    return lhs.has_value() ? *lhs == rhs : false;
-  }
-  /// \group relop_t
-  template <class T, class U>
-  inline constexpr bool operator==(const U &lhs, const optional<T> &rhs) {
-    return rhs.has_value() ? lhs == *rhs : false;
-  }
-  /// \group relop_t
-  template <class T, class U>
-  inline constexpr bool operator!=(const optional<T> &lhs, const U &rhs) {
-    return lhs.has_value() ? *lhs != rhs : true;
-  }
-  /// \group relop_t
-  template <class T, class U>
-  inline constexpr bool operator!=(const U &lhs, const optional<T> &rhs) {
-    return rhs.has_value() ? lhs != *rhs : true;
-  }
-  /// \group relop_t
-  template <class T, class U>
-  inline constexpr bool operator<(const optional<T> &lhs, const U &rhs) {
-    return lhs.has_value() ? *lhs < rhs : true;
-  }
-  /// \group relop_t
-  template <class T, class U>
-  inline constexpr bool operator<(const U &lhs, const optional<T> &rhs) {
-    return rhs.has_value() ? lhs < *rhs : false;
-  }
-  /// \group relop_t
-  template <class T, class U>
-  inline constexpr bool operator<=(const optional<T> &lhs, const U &rhs) {
-    return lhs.has_value() ? *lhs <= rhs : true;
-  }
-  /// \group relop_t
-  template <class T, class U>
-  inline constexpr bool operator<=(const U &lhs, const optional<T> &rhs) {
-    return rhs.has_value() ? lhs <= *rhs : false;
-  }
-  /// \group relop_t
-  template <class T, class U>
-  inline constexpr bool operator>(const optional<T> &lhs, const U &rhs) {
-    return lhs.has_value() ? *lhs > rhs : false;
-  }
-  /// \group relop_t
-  template <class T, class U>
-  inline constexpr bool operator>(const U &lhs, const optional<T> &rhs) {
-    return rhs.has_value() ? lhs > *rhs : true;
-  }
-  /// \group relop_t
-  template <class T, class U>
-  inline constexpr bool operator>=(const optional<T> &lhs, const U &rhs) {
-    return lhs.has_value() ? *lhs >= rhs : false;
-  }
-  /// \group relop_t
-  template <class T, class U>
-  inline constexpr bool operator>=(const U &lhs, const optional<T> &rhs) {
-    return rhs.has_value() ? lhs >= *rhs : true;
+  /// \group map
+  /// \synopsis template <class F> constexpr auto map(F &&f) const&;
+  template <class F> constexpr auto map(F &&f) const & {
+    return map_impl(*this, std::forward<F>(f));
   }
 
-  /// \synopsis template <class T>\nvoid swap(optional<T> &lhs, optional<T>
-  /// &rhs);
-  template <class T,
-            detail::enable_if_t<std::is_move_constructible<T>::value> * =
-                nullptr,
-            detail::enable_if_t<detail::is_swappable<T>::value> * = nullptr>
-  void swap(optional<T> & lhs,
-            optional<T> & rhs) noexcept(noexcept(lhs.swap(rhs))) {
-    return lhs.swap(rhs);
-  }
-
-  template <class T>
-  inline constexpr optional<detail::decay_t<T>> make_optional(T && v) {
-    return optional<detail::decay_t<T>>(std::forward<T>(v));
-  }
-  template <class T, class... Args>
-  inline constexpr optional<T> make_optional(Args && ... args) {
-    return optional<T>(in_place, std::forward<Args>(args)...);
-  }
-  template <class T, class U, class... Args>
-  inline constexpr optional<T> make_optional(std::initializer_list<U> il,
-                                             Args && ... args) {
-    return optional<T>(in_place, il, std::forward<Args>(args)...);
-  }
-
-#if __cplusplus >= 201703L
-  template <class T> optional(T)->optional<T>;
-#endif
-
-  /// \exclude
-  namespace detail {
-#ifdef TL_OPTIONAL_CX14
-  template <class Opt, class F,
-            class Ret = decltype(detail::invoke(std::declval<F>(),
-                                                *std::declval<Opt>())),
-            detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
-  constexpr auto map_impl(Opt &&opt, F &&f) {
-    return opt.has_value()
-               ? detail::invoke(std::forward<F>(f), *std::forward<Opt>(opt))
-               : optional<detail::decay_t<Ret>>(nullopt);
-  }
-
-  template <class Opt, class F,
-            class Ret = decltype(detail::invoke(std::declval<F>(),
-                                                *std::declval<Opt>())),
-            detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
-  auto map_impl(Opt &&opt, F &&f) {
-    if (opt.has_value()) {
-      detail::invoke(std::forward<F>(f), *std::forward<Opt>(opt));
-      return monostate{};
-    }
-
-    return optional<Ret>(nullopt);
+  /// \group map
+  /// \synopsis template <class F> constexpr auto map(F &&f) const&&;
+  template <class F> constexpr auto map(F &&f) const && {
+    return map_impl(std::move(*this), std::forward<F>(f));
   }
 #else
-  template <class Opt, class F,
-            class Ret = decltype(detail::invoke(std::declval<F>(),
-                                                *std::declval<Opt>())),
-            detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
-
-  constexpr auto map_impl(Opt &&opt, F &&f) -> optional<detail::decay_t<Ret>> {
-    return opt.has_value()
-               ? detail::invoke(std::forward<F>(f), *std::forward<Opt>(opt))
-               : optional<detail::decay_t<Ret>>(nullopt);
+  /// \brief Carries out some operation on the stored object if there is one.
+  /// \returns Let `U` be the result of `std::invoke(std::forward<F>(f),
+  /// value())`. Returns a `std::optional<U>`. The return value is empty if
+  /// `*this` is empty, otherwise an `optional<U>` is constructed from the
+  /// return value of `std::invoke(std::forward<F>(f), value())` and is
+  /// returned.
+  ///
+  /// \group map
+  /// \synopsis template <class F> auto map(F &&f) &;
+  template <class F>
+  TL_OPTIONAL_11_CONSTEXPR decltype(map_impl(std::declval<optional &>(),
+                                             std::declval<F &&>()))
+  map(F &&f) & {
+    return map_impl(*this, std::forward<F>(f));
   }
 
-  template <class Opt, class F,
-            class Ret = decltype(detail::invoke(std::declval<F>(),
-                                                *std::declval<Opt>())),
-            detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+  /// \group map
+  /// \synopsis template <class F> auto map(F &&f) &&;
+  template <class F>
+  TL_OPTIONAL_11_CONSTEXPR decltype(map_impl(std::declval<optional &&>(),
+                                             std::declval<F &&>()))
+  map(F &&f) && {
+    return map_impl(std::move(*this), std::forward<F>(f));
+  }
 
-  auto map_impl(Opt &&opt, F &&f) -> optional<monostate> {
-    if (opt.has_value()) {
-      detail::invoke(std::forward<F>(f), *std::forward<Opt>(opt));
-      return monostate{};
-    }
+  /// \group map
+  /// \synopsis template <class F> auto map(F &&f) const&;
+  template <class F>
+  constexpr decltype(map_impl(std::declval<const optional &>(),
+                              std::declval<F &&>()))
+  map(F &&f) const & {
+    return map_impl(*this, std::forward<F>(f));
+  }
 
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \group map
+  /// \synopsis template <class F> auto map(F &&f) const&&;
+  template <class F>
+  constexpr decltype(map_impl(std::declval<const optional &&>(),
+                              std::declval<F &&>()))
+  map(F &&f) const && {
+    return map_impl(std::move(*this), std::forward<F>(f));
+  }
+#endif
+#endif
+
+  /// \brief Calls `f` if the optional is empty
+  /// \requires `std::invoke_result_t<F>` must be void or convertible to
+  /// `optional<T>`. \effects If `*this` has a value, returns `*this`.
+  /// Otherwise, if `f` returns `void`, calls `std::forward<F>(f)` and returns
+  /// `std::nullopt`. Otherwise, returns `std::forward<F>(f)()`.
+  ///
+  /// \group or_else
+  /// \synopsis template <class F> optional<T> or_else (F &&f) &;
+  template <class F, detail::enable_if_ret_void<F> * = nullptr>
+  optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) & {
+    if (has_value())
+      return *this;
+
+    std::forward<F>(f)();
     return nullopt;
   }
+
+  /// \exclude
+  template <class F, detail::disable_if_ret_void<F> * = nullptr>
+  optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) & {
+    return has_value() ? *this : std::forward<F>(f)();
+  }
+
+  /// \group or_else
+  /// \synopsis template <class F> optional<T> or_else (F &&f) &&;
+  template <class F, detail::enable_if_ret_void<F> * = nullptr>
+  optional<T> or_else(F &&f) && {
+    if (has_value())
+      return std::move(*this);
+
+    std::forward<F>(f)();
+    return nullopt;
+  }
+
+  /// \exclude
+  template <class F, detail::disable_if_ret_void<F> * = nullptr>
+  optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) && {
+    return has_value() ? std::move(*this) : std::forward<F>(f)();
+  }
+
+  /// \group or_else
+  /// \synopsis template <class F> optional<T> or_else (F &&f) const &;
+  template <class F, detail::enable_if_ret_void<F> * = nullptr>
+  optional<T> or_else(F &&f) const & {
+    if (has_value())
+      return *this;
+
+    std::forward<F>(f)();
+    return nullopt;
+  }
+
+  /// \exclude
+  template <class F, detail::disable_if_ret_void<F> * = nullptr>
+  optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) const & {
+    return has_value() ? *this : std::forward<F>(f)();
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \exclude
+  template <class F, detail::enable_if_ret_void<F> * = nullptr>
+  optional<T> or_else(F &&f) const && {
+    if (has_value())
+      return std::move(*this);
+
+    std::forward<F>(f)();
+    return nullopt;
+  }
+
+  /// \exclude
+  template <class F, detail::disable_if_ret_void<F> * = nullptr>
+  optional<T> or_else(F &&f) const && {
+    return has_value() ? std::move(*this) : std::forward<F>(f)();
+  }
 #endif
-  } // namespace detail
+
+  /// \brief Maps the stored value with `f` if there is one, otherwise returns
+  /// `u`.
+  ///
+  /// \details If there is a value stored, then `f` is called with `**this`
+  /// and the value is returned. Otherwise `u` is returned.
+  ///
+  /// \group map_or
+  template <class F, class U> U map_or(F &&f, U &&u) & {
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : std::forward<U>(u);
+  }
+
+  /// \group map_or
+  template <class F, class U> U map_or(F &&f, U &&u) && {
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : std::forward<U>(u);
+  }
+
+  /// \group map_or
+  template <class F, class U> U map_or(F &&f, U &&u) const & {
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : std::forward<U>(u);
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \group map_or
+  template <class F, class U> U map_or(F &&f, U &&u) const && {
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : std::forward<U>(u);
+  }
+#endif
+
+  /// \brief Maps the stored value with `f` if there is one, otherwise calls
+  /// `u` and returns the result.
+  ///
+  /// \details If there is a value stored, then `f` is
+  /// called with `**this` and the value is returned. Otherwise
+  /// `std::forward<U>(u)()` is returned.
+  ///
+  /// \group map_or_else
+  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u) &;
+  template <class F, class U>
+  detail::invoke_result_t<U> map_or_else(F &&f, U &&u) & {
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : std::forward<U>(u)();
+  }
+
+  /// \group map_or_else
+  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u)
+  /// &&;
+  template <class F, class U>
+  detail::invoke_result_t<U> map_or_else(F &&f, U &&u) && {
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : std::forward<U>(u)();
+  }
+
+  /// \group map_or_else
+  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u)
+  /// const &;
+  template <class F, class U>
+  detail::invoke_result_t<U> map_or_else(F &&f, U &&u) const & {
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : std::forward<U>(u)();
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \group map_or_else
+  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u)
+  /// const &&;
+  template <class F, class U>
+  detail::invoke_result_t<U> map_or_else(F &&f, U &&u) const && {
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : std::forward<U>(u)();
+  }
+#endif
+
+  /// \returns `u` if `*this` has a value, otherwise an empty optional.
+  template <class U>
+  constexpr optional<typename std::decay<U>::type> conjunction(U &&u) const {
+    using result = optional<detail::decay_t<U>>;
+    return has_value() ? result{u} : result{nullopt};
+  }
+
+  /// \returns `rhs` if `*this` is empty, otherwise the current value.
+  /// \group disjunction
+  TL_OPTIONAL_11_CONSTEXPR optional disjunction(const optional &rhs) & {
+    return has_value() ? *this : rhs;
+  }
+
+  /// \group disjunction
+  constexpr optional disjunction(const optional &rhs) const & {
+    return has_value() ? *this : rhs;
+  }
+
+  /// \group disjunction
+  TL_OPTIONAL_11_CONSTEXPR optional disjunction(const optional &rhs) && {
+    return has_value() ? std::move(*this) : rhs;
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \group disjunction
+  constexpr optional disjunction(const optional &rhs) const && {
+    return has_value() ? std::move(*this) : rhs;
+  }
+#endif
+
+  /// \group disjunction
+  TL_OPTIONAL_11_CONSTEXPR optional disjunction(optional &&rhs) & {
+    return has_value() ? *this : std::move(rhs);
+  }
+
+  /// \group disjunction
+  constexpr optional disjunction(optional &&rhs) const & {
+    return has_value() ? *this : std::move(rhs);
+  }
+
+  /// \group disjunction
+  TL_OPTIONAL_11_CONSTEXPR optional disjunction(optional &&rhs) && {
+    return has_value() ? std::move(*this) : std::move(rhs);
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \group disjunction
+  constexpr optional disjunction(optional &&rhs) const && {
+    return has_value() ? std::move(*this) : std::move(rhs);
+  }
+#endif
+
+  /// Takes the value out of the optional, leaving it empty
+  /// \group take
+  optional take() & {
+    optional ret = *this;
+    reset();
+    return ret;
+  }
+
+  /// \group take
+  optional take() const & {
+    optional ret = *this;
+    reset();
+    return ret;
+  }
+
+  /// \group take
+  optional take() && {
+    optional ret = std::move(*this);
+    reset();
+    return ret;
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \group take
+  optional take() const && {
+    optional ret = std::move(*this);
+    reset();
+    return ret;
+  }
+#endif
+
+  using value_type = T;
+
+  /// Constructs an optional that does not contain a value.
+  /// \group ctor_empty
+  constexpr optional() noexcept = default;
+
+  /// \group ctor_empty
+  constexpr optional(nullopt_t) noexcept {}
+
+  /// Copy constructor
+  ///
+  /// If `rhs` contains a value, the stored value is direct-initialized with
+  /// it. Otherwise, the constructed optional is empty.
+  TL_OPTIONAL_11_CONSTEXPR optional(const optional &rhs) = default;
+
+  /// Move constructor
+  ///
+  /// If `rhs` contains a value, the stored value is direct-initialized with
+  /// it. Otherwise, the constructed optional is empty.
+  TL_OPTIONAL_11_CONSTEXPR optional(optional &&rhs) = default;
+
+  /// Constructs the stored value in-place using the given arguments.
+  /// \group in_place
+  /// \synopsis template <class... Args> constexpr explicit
+  /// optional(in_place_t, Args&&... args);
+  template <class... Args>
+  constexpr explicit optional(
+      detail::enable_if_t<std::is_constructible<T, Args...>::value, in_place_t>,
+      Args &&... args)
+      : base(in_place, std::forward<Args>(args)...) {}
+
+  /// \group in_place
+  /// \synopsis template <class U, class... Args>\nconstexpr explicit
+  /// optional(in_place_t, std::initializer_list<U>&, Args&&... args);
+  template <class U, class... Args>
+  TL_OPTIONAL_11_CONSTEXPR explicit optional(
+      detail::enable_if_t<std::is_constructible<T, std::initializer_list<U> &,
+                                                Args &&...>::value,
+                          in_place_t>,
+      std::initializer_list<U> il, Args &&... args) {
+    this->construct(il, std::forward<Args>(args)...);
+  }
+
+  /// Constructs the stored value with `u`.
+  /// \synopsis template <class U=T> constexpr optional(U &&u);
+  template <
+      class U = T,
+      detail::enable_if_t<std::is_convertible<U &&, T>::value> * = nullptr,
+      detail::enable_forward_value<T, U> * = nullptr>
+  constexpr optional(U &&u) : base(in_place, std::forward<U>(u)) {}
+
+  /// \exclude
+  template <
+      class U = T,
+      detail::enable_if_t<!std::is_convertible<U &&, T>::value> * = nullptr,
+      detail::enable_forward_value<T, U> * = nullptr>
+  constexpr explicit optional(U &&u) : base(in_place, std::forward<U>(u)) {}
+
+  /// Converting copy constructor.
+  /// \synopsis template <class U> optional(const optional<U> &rhs);
+  template <
+      class U, detail::enable_from_other<T, U, const U &> * = nullptr,
+      detail::enable_if_t<std::is_convertible<const U &, T>::value> * = nullptr>
+  optional(const optional<U> &rhs) {
+    this->construct(*rhs);
+  }
+
+  /// \exclude
+  template <class U, detail::enable_from_other<T, U, const U &> * = nullptr,
+            detail::enable_if_t<!std::is_convertible<const U &, T>::value> * =
+                nullptr>
+  explicit optional(const optional<U> &rhs) {
+    this->construct(*rhs);
+  }
+
+  /// Converting move constructor.
+  /// \synopsis template <class U> optional(optional<U> &&rhs);
+  template <
+      class U, detail::enable_from_other<T, U, U &&> * = nullptr,
+      detail::enable_if_t<std::is_convertible<U &&, T>::value> * = nullptr>
+  optional(optional<U> &&rhs) {
+    this->construct(std::move(*rhs));
+  }
+
+  /// \exclude
+  template <
+      class U, detail::enable_from_other<T, U, U &&> * = nullptr,
+      detail::enable_if_t<!std::is_convertible<U &&, T>::value> * = nullptr>
+  explicit optional(optional<U> &&rhs) {
+    this->construct(std::move(*rhs));
+  }
+
+  /// Destroys the stored value if there is one.
+  ~optional() = default;
+
+  /// Assignment to empty.
+  ///
+  /// Destroys the current value if there is one.
+  optional &operator=(nullopt_t) noexcept {
+    if (has_value()) {
+      this->m_value.~T();
+      this->m_has_value = false;
+    }
+
+    return *this;
+  }
+
+  /// Copy assignment.
+  ///
+  /// Copies the value from `rhs` if there is one. Otherwise resets the stored
+  /// value in `*this`.
+  optional &operator=(const optional &rhs) = default;
+
+  /// Move assignment.
+  ///
+  /// Moves the value from `rhs` if there is one. Otherwise resets the stored
+  /// value in `*this`.
+  optional &operator=(optional &&rhs) = default;
+
+  /// Assigns the stored value from `u`, destroying the old value if there was
+  /// one.
+  /// \synopsis optional &operator=(U &&u);
+  template <class U = T, detail::enable_assign_forward<T, U> * = nullptr>
+  optional &operator=(U &&u) {
+    if (has_value()) {
+      this->m_value = std::forward<U>(u);
+    } else {
+      this->construct(std::forward<U>(u));
+    }
+
+    return *this;
+  }
+
+  /// Converting copy assignment operator.
+  ///
+  /// Copies the value from `rhs` if there is one. Otherwise resets the stored
+  /// value in `*this`.
+  /// \synopsis optional &operator=(const optional<U> & rhs);
+  template <class U,
+            detail::enable_assign_from_other<T, U, const U &> * = nullptr>
+  optional &operator=(const optional<U> &rhs) {
+    if (has_value()) {
+      if (rhs.has_value()) {
+        this->m_value = *rhs;
+      } else {
+        this->hard_reset();
+      }
+    }
+
+    if (rhs.has_value()) {
+      this->construct(*rhs);
+    }
+
+    return *this;
+  }
+
+  // TODO check exception guarantee
+  /// Converting move assignment operator.
+  ///
+  /// Moves the value from `rhs` if there is one. Otherwise resets the stored
+  /// value in `*this`.
+  /// \synopsis optional &operator=(optional<U> && rhs);
+  template <class U, detail::enable_assign_from_other<T, U, U> * = nullptr>
+  optional &operator=(optional<U> &&rhs) {
+    if (has_value()) {
+      if (rhs.has_value()) {
+        this->m_value = std::move(*rhs);
+      } else {
+        this->hard_reset();
+      }
+    }
+
+    if (rhs.has_value()) {
+      this->construct(std::move(*rhs));
+    }
+
+    return *this;
+  }
+
+  /// Constructs the value in-place, destroying the current one if there is
+  /// one. \group emplace
+  template <class... Args> T &emplace(Args &&... args) {
+    static_assert(std::is_constructible<T, Args &&...>::value,
+                  "T must be constructible with Args");
+
+    *this = nullopt;
+    this->construct(std::forward<Args>(args)...);
+  }
+
+  /// \group emplace
+  /// \synopsis template <class U, class... Args>\nT&
+  /// emplace(std::initializer_list<U> il, Args &&... args);
+  template <class U, class... Args>
+  detail::enable_if_t<
+      std::is_constructible<T, std::initializer_list<U> &, Args &&...>::value,
+      T &>
+  emplace(std::initializer_list<U> il, Args &&... args) {
+    *this = nullopt;
+    this->construct(il, std::forward<Args>(args)...);
+  }
+
+  /// Swaps this optional with the other.
+  ///
+  /// If neither optionals have a value, nothing happens.
+  /// If both have a value, the values are swapped.
+  /// If one has a value, it is moved to the other and the movee is left
+  /// valueless.
+  void
+  swap(optional &rhs) noexcept(std::is_nothrow_move_constructible<T>::value
+                                   &&detail::is_nothrow_swappable<T>::value) {
+    if (has_value()) {
+      if (rhs.has_value()) {
+        using std::swap;
+        swap(**this, *rhs);
+      } else {
+        new (std::addressof(rhs.m_value)) T(std::move(this->m_value));
+        this->m_value.T::~T();
+      }
+    } else if (rhs.has_value()) {
+      new (std::addressof(this->m_value)) T(std::move(rhs.m_value));
+      rhs.m_value.T::~T();
+    }
+  }
+
+  /// \returns a pointer to the stored value
+  /// \requires a value is stored
+  /// \group pointer
+  /// \synopsis constexpr const T *operator->() const;
+  constexpr const T *operator->() const {
+    return std::addressof(this->m_value);
+  }
+
+  /// \group pointer
+  /// \synopsis constexpr T *operator->();
+  TL_OPTIONAL_11_CONSTEXPR T *operator->() {
+    return std::addressof(this->m_value);
+  }
+
+  /// \returns the stored value
+  /// \requires a value is stored
+  /// \group deref
+  /// \synopsis constexpr T &operator*();
+  TL_OPTIONAL_11_CONSTEXPR T &operator*() & { return this->m_value; }
+
+  /// \group deref
+  /// \synopsis constexpr const T &operator*() const;
+  constexpr const T &operator*() const & { return this->m_value; }
+
+  /// \exclude
+  TL_OPTIONAL_11_CONSTEXPR T &&operator*() && {
+    return std::move(this->m_value);
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \exclude
+  constexpr const T &&operator*() const && { return std::move(this->m_value); }
+#endif
+
+  /// \returns whether or not the optional has a value
+  /// \group has_value
+  constexpr bool has_value() const noexcept { return this->m_has_value; }
+
+  /// \group has_value
+  constexpr explicit operator bool() const noexcept {
+    return this->m_has_value;
+  }
+
+  /// \returns the contained value if there is one, otherwise throws
+  /// [bad_optional_access]
+  /// \group value
+  /// synopsis constexpr T &value();
+  TL_OPTIONAL_11_CONSTEXPR T &value() & {
+    if (has_value())
+      return this->m_value;
+    throw bad_optional_access();
+  }
+  /// \group value
+  /// \synopsis constexpr const T &value() const;
+  TL_OPTIONAL_11_CONSTEXPR const T &value() const & {
+    if (has_value())
+      return this->m_value;
+    throw bad_optional_access();
+  }
+  /// \exclude
+  TL_OPTIONAL_11_CONSTEXPR T &&value() && {
+    if (has_value())
+      return std::move(this->m_value);
+    throw bad_optional_access();
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \exclude
+  constexpr const T &&value() const && {
+    if (has_value())
+      return std::move(this->m_value);
+    throw bad_optional_access();
+  }
+#endif
+
+  /// \returns the stored value if there is one, otherwise returns `u`
+  /// \group value_or
+  template <class U> constexpr T value_or(U &&u) const & {
+    static_assert(std::is_copy_constructible<T>::value &&
+                      std::is_convertible<U &&, T>::value,
+                  "T must be copy constructible and convertible from U");
+    return has_value() ? **this : static_cast<T>(std::forward<U>(u));
+  }
+
+  /// \group value_or
+  template <class U> constexpr T value_or(U &&u) && {
+    static_assert(std::is_move_constructible<T>::value &&
+                      std::is_convertible<U &&, T>::value,
+                  "T must be move constructible and convertible from U");
+    return has_value() ? **this : static_cast<T>(std::forward<U>(u));
+  }
+
+  /// Destroys the stored value if one exists, making the optional empty
+  void reset() noexcept {
+    if (has_value()) {
+      this->m_value.~T();
+      this->m_has_value = false;
+    }
+  }
+}; // namespace tl
+
+/// \group relop
+/// \brief Compares two optional objects
+/// \details If both optionals contain a value, they are compared with `T`s
+/// relational operators. Otherwise `lhs` and `rhs` are equal only if they are
+/// both empty, and `lhs` is less than `rhs` only if `rhs` is empty and `lhs`
+/// is not.
+template <class T, class U>
+inline constexpr bool operator==(const optional<T> &lhs,
+                                 const optional<U> &rhs) {
+  return lhs.has_value() == rhs.has_value() &&
+         (!lhs.has_value() || *lhs == *rhs);
+}
+/// \group relop
+template <class T, class U>
+inline constexpr bool operator!=(const optional<T> &lhs,
+                                 const optional<U> &rhs) {
+  return lhs.has_value() != rhs.has_value() ||
+         (lhs.has_value() && *lhs != *rhs);
+}
+/// \group relop
+template <class T, class U>
+inline constexpr bool operator<(const optional<T> &lhs,
+                                const optional<U> &rhs) {
+  return rhs.has_value() && (!lhs.has_value() || *lhs < *rhs);
+}
+/// \group relop
+template <class T, class U>
+inline constexpr bool operator>(const optional<T> &lhs,
+                                const optional<U> &rhs) {
+  return lhs.has_value() && (!rhs.has_value() || *lhs > *rhs);
+}
+/// \group relop
+template <class T, class U>
+inline constexpr bool operator<=(const optional<T> &lhs,
+                                 const optional<U> &rhs) {
+  return !lhs.has_value() || (rhs.has_value() && *lhs <= *rhs);
+}
+/// \group relop
+template <class T, class U>
+inline constexpr bool operator>=(const optional<T> &lhs,
+                                 const optional<U> &rhs) {
+  return !rhs.has_value() || (lhs.has_value() && *lhs >= *rhs);
+}
+
+/// \group relop_nullopt
+/// \brief Compares an optional to a `nullopt`
+/// \details Equivalent to comparing the optional to an empty optional
+template <class T>
+inline constexpr bool operator==(const optional<T> &lhs, nullopt_t) noexcept {
+  return !lhs.has_value();
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator==(nullopt_t, const optional<T> &rhs) noexcept {
+  return !rhs.has_value();
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator!=(const optional<T> &lhs, nullopt_t) noexcept {
+  return lhs.has_value();
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator!=(nullopt_t, const optional<T> &rhs) noexcept {
+  return rhs.has_value();
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator<(const optional<T> &, nullopt_t) noexcept {
+  return false;
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator<(nullopt_t, const optional<T> &rhs) noexcept {
+  return rhs.has_value();
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator<=(const optional<T> &lhs, nullopt_t) noexcept {
+  return !lhs.has_value();
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator<=(nullopt_t, const optional<T> &) noexcept {
+  return true;
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator>(const optional<T> &lhs, nullopt_t) noexcept {
+  return lhs.has_value();
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator>(nullopt_t, const optional<T> &) noexcept {
+  return false;
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator>=(const optional<T> &, nullopt_t) noexcept {
+  return true;
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator>=(nullopt_t, const optional<T> &rhs) noexcept {
+  return !rhs.has_value();
+}
+
+/// \group relop_t
+/// \brief Compares the optional with a value.
+/// \details If the optional has a value, it is compared with the other value
+/// using `T`s relational operators. Otherwise, the optional is considered
+/// less than the value.
+template <class T, class U>
+inline constexpr bool operator==(const optional<T> &lhs, const U &rhs) {
+  return lhs.has_value() ? *lhs == rhs : false;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator==(const U &lhs, const optional<T> &rhs) {
+  return rhs.has_value() ? lhs == *rhs : false;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator!=(const optional<T> &lhs, const U &rhs) {
+  return lhs.has_value() ? *lhs != rhs : true;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator!=(const U &lhs, const optional<T> &rhs) {
+  return rhs.has_value() ? lhs != *rhs : true;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator<(const optional<T> &lhs, const U &rhs) {
+  return lhs.has_value() ? *lhs < rhs : true;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator<(const U &lhs, const optional<T> &rhs) {
+  return rhs.has_value() ? lhs < *rhs : false;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator<=(const optional<T> &lhs, const U &rhs) {
+  return lhs.has_value() ? *lhs <= rhs : true;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator<=(const U &lhs, const optional<T> &rhs) {
+  return rhs.has_value() ? lhs <= *rhs : false;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator>(const optional<T> &lhs, const U &rhs) {
+  return lhs.has_value() ? *lhs > rhs : false;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator>(const U &lhs, const optional<T> &rhs) {
+  return rhs.has_value() ? lhs > *rhs : true;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator>=(const optional<T> &lhs, const U &rhs) {
+  return lhs.has_value() ? *lhs >= rhs : false;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator>=(const U &lhs, const optional<T> &rhs) {
+  return rhs.has_value() ? lhs >= *rhs : true;
+}
+
+/// \synopsis template <class T>\nvoid swap(optional<T> &lhs, optional<T>
+/// &rhs);
+template <class T,
+          detail::enable_if_t<std::is_move_constructible<T>::value> * = nullptr,
+          detail::enable_if_t<detail::is_swappable<T>::value> * = nullptr>
+void swap(optional<T> &lhs,
+          optional<T> &rhs) noexcept(noexcept(lhs.swap(rhs))) {
+  return lhs.swap(rhs);
+}
+
+template <class T>
+inline constexpr optional<detail::decay_t<T>> make_optional(T &&v) {
+  return optional<detail::decay_t<T>>(std::forward<T>(v));
+}
+template <class T, class... Args>
+inline constexpr optional<T> make_optional(Args &&... args) {
+  return optional<T>(in_place, std::forward<Args>(args)...);
+}
+template <class T, class U, class... Args>
+inline constexpr optional<T> make_optional(std::initializer_list<U> il,
+                                           Args &&... args) {
+  return optional<T>(in_place, il, std::forward<Args>(args)...);
+}
+
+#if __cplusplus >= 201703L
+template <class T> optional(T)->optional<T>;
+#endif
+
+/// An optional object is an object that contains the storage for another
+/// object and manages the lifetime of this contained object, if any. The
+/// contained object may be initialized after the optional object has been
+/// initialized, and may be destroyed before the optional object has been
+/// destroyed. The initialization state of the contained object is tracked by
+/// the optional object.
+template <class T> class optional<T &> {
+public:
+// The different versions for C++14 and 11 are needed because deduced return
+// types are not SFINAE-safe. This provides better support for things like
+// generic lambdas. C.f.
+// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0826r0.html
+#if defined(TL_OPTIONAL_CXX14) && !defined(TL_OPTIONAL_GCC49) &&               \
+    !defined(TL_OPTIONAL_GCC54)
+  /// \group and_then
+  /// Carries out some operation which returns an optional on the stored
+  /// object if there is one. \requires `std::invoke(std::forward<F>(f),
+  /// value())` returns a `std::optional<U>` for some `U`. \returns Let `U` be
+  /// the result of `std::invoke(std::forward<F>(f), value())`. Returns a
+  /// `std::optional<U>`. The return value is empty if `*this` is empty,
+  /// otherwise the return value of `std::invoke(std::forward<F>(f), value())`
+  /// is returned.
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &;
+  template <class F> TL_OPTIONAL_11_CONSTEXPR auto and_then(F &&f) & {
+    using result = detail::invoke_result_t<F, T &>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
+
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : result(nullopt);
+  }
+
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &&;
+  template <class F> TL_OPTIONAL_11_CONSTEXPR auto and_then(F &&f) && {
+    using result = detail::invoke_result_t<F, T &&>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
+
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : result(nullopt);
+  }
+
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &;
+  template <class F> constexpr auto and_then(F &&f) const & {
+    using result = detail::invoke_result_t<F, const T &>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
+
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : result(nullopt);
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &&;
+  template <class F> constexpr auto and_then(F &&f) const && {
+    using result = detail::invoke_result_t<F, const T &&>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
+
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : result(nullopt);
+  }
+#endif
+#else
+  /// \group and_then
+  /// Carries out some operation which returns an optional on the stored
+  /// object if there is one. \requires `std::invoke(std::forward<F>(f),
+  /// value())` returns a `std::optional<U>` for some `U`. \returns Let `U` be
+  /// the result of `std::invoke(std::forward<F>(f), value())`. Returns a
+  /// `std::optional<U>`. The return value is empty if `*this` is empty,
+  /// otherwise the return value of `std::invoke(std::forward<F>(f), value())`
+  /// is returned.
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &;
+  template <class F>
+  TL_OPTIONAL_11_CONSTEXPR detail::invoke_result_t<F, T &> and_then(F &&f) & {
+    using result = detail::invoke_result_t<F, T &>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
+
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : result(nullopt);
+  }
+
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &&;
+  template <class F>
+  TL_OPTIONAL_11_CONSTEXPR detail::invoke_result_t<F, T &&> and_then(F &&f) && {
+    using result = detail::invoke_result_t<F, T &&>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
+
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : result(nullopt);
+  }
+
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &;
+  template <class F>
+  constexpr detail::invoke_result_t<F, const T &> and_then(F &&f) const & {
+    using result = detail::invoke_result_t<F, const T &>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
+
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : result(nullopt);
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \group and_then
+  /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) const &&;
+  template <class F>
+  constexpr detail::invoke_result_t<F, const T &&> and_then(F &&f) const && {
+    using result = detail::invoke_result_t<F, const T &&>;
+    static_assert(detail::is_optional<result>::value,
+                  "F must return an optional");
+
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : result(nullopt);
+  }
+#endif
+#endif
+
+#if defined(TL_OPTIONAL_CXX14) && !defined(TL_OPTIONAL_GCC49) &&               \
+    !defined(TL_OPTIONAL_GCC54)
+  /// \brief Carries out some operation on the stored object if there is one.
+  /// \returns Let `U` be the result of `std::invoke(std::forward<F>(f),
+  /// value())`. Returns a `std::optional<U>`. The return value is empty if
+  /// `*this` is empty, otherwise an `optional<U>` is constructed from the
+  /// return value of `std::invoke(std::forward<F>(f), value())` and is
+  /// returned.
+  ///
+  /// \group map
+  /// \synopsis template <class F> constexpr auto map(F &&f) &;
+  template <class F> TL_OPTIONAL_11_CONSTEXPR auto map(F &&f) & {
+    return map_impl(*this, std::forward<F>(f));
+  }
+
+  /// \group map
+  /// \synopsis template <class F> constexpr auto map(F &&f) &&;
+  template <class F> TL_OPTIONAL_11_CONSTEXPR auto map(F &&f) && {
+    return map_impl(std::move(*this), std::forward<F>(f));
+  }
+
+  /// \group map
+  /// \synopsis template <class F> constexpr auto map(F &&f) const&;
+  template <class F> constexpr auto map(F &&f) const & {
+    return map_impl(*this, std::forward<F>(f));
+  }
+
+  /// \group map
+  /// \synopsis template <class F> constexpr auto map(F &&f) const&&;
+  template <class F> constexpr auto map(F &&f) const && {
+    return map_impl(std::move(*this), std::forward<F>(f));
+  }
+#else
+  /// \brief Carries out some operation on the stored object if there is one.
+  /// \returns Let `U` be the result of `std::invoke(std::forward<F>(f),
+  /// value())`. Returns a `std::optional<U>`. The return value is empty if
+  /// `*this` is empty, otherwise an `optional<U>` is constructed from the
+  /// return value of `std::invoke(std::forward<F>(f), value())` and is
+  /// returned.
+  ///
+  /// \group map
+  /// \synopsis template <class F> auto map(F &&f) &;
+  template <class F>
+  TL_OPTIONAL_11_CONSTEXPR decltype(map_impl(std::declval<optional &>(),
+                                             std::declval<F &&>()))
+  map(F &&f) & {
+    return map_impl(*this, std::forward<F>(f));
+  }
+
+  /// \group map
+  /// \synopsis template <class F> auto map(F &&f) &&;
+  template <class F>
+  TL_OPTIONAL_11_CONSTEXPR decltype(map_impl(std::declval<optional &&>(),
+                                             std::declval<F &&>()))
+  map(F &&f) && {
+    return map_impl(std::move(*this), std::forward<F>(f));
+  }
+
+  /// \group map
+  /// \synopsis template <class F> auto map(F &&f) const&;
+  template <class F>
+  constexpr decltype(map_impl(std::declval<const optional &>(),
+                              std::declval<F &&>()))
+  map(F &&f) const & {
+    return map_impl(*this, std::forward<F>(f));
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \group map
+  /// \synopsis template <class F> auto map(F &&f) const&&;
+  template <class F>
+  constexpr decltype(map_impl(std::declval<const optional &&>(),
+                              std::declval<F &&>()))
+  map(F &&f) const && {
+    return map_impl(std::move(*this), std::forward<F>(f));
+  }
+#endif
+#endif
+
+  /// \brief Calls `f` if the optional is empty
+  /// \requires `std::invoke_result_t<F>` must be void or convertible to
+  /// `optional<T>`. \effects If `*this` has a value, returns `*this`.
+  /// Otherwise, if `f` returns `void`, calls `std::forward<F>(f)` and returns
+  /// `std::nullopt`. Otherwise, returns `std::forward<F>(f)()`.
+  ///
+  /// \group or_else
+  /// \synopsis template <class F> optional<T> or_else (F &&f) &;
+  template <class F, detail::enable_if_ret_void<F> * = nullptr>
+  optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) & {
+    if (has_value())
+      return *this;
+
+    std::forward<F>(f)();
+    return nullopt;
+  }
+
+  /// \exclude
+  template <class F, detail::disable_if_ret_void<F> * = nullptr>
+  optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) & {
+    return has_value() ? *this : std::forward<F>(f)();
+  }
+
+  /// \group or_else
+  /// \synopsis template <class F> optional<T> or_else (F &&f) &&;
+  template <class F, detail::enable_if_ret_void<F> * = nullptr>
+  optional<T> or_else(F &&f) && {
+    if (has_value())
+      return std::move(*this);
+
+    std::forward<F>(f)();
+    return nullopt;
+  }
+
+  /// \exclude
+  template <class F, detail::disable_if_ret_void<F> * = nullptr>
+  optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) && {
+    return has_value() ? std::move(*this) : std::forward<F>(f)();
+  }
+
+  /// \group or_else
+  /// \synopsis template <class F> optional<T> or_else (F &&f) const &;
+  template <class F, detail::enable_if_ret_void<F> * = nullptr>
+  optional<T> or_else(F &&f) const & {
+    if (has_value())
+      return *this;
+
+    std::forward<F>(f)();
+    return nullopt;
+  }
+
+  /// \exclude
+  template <class F, detail::disable_if_ret_void<F> * = nullptr>
+  optional<T> TL_OPTIONAL_11_CONSTEXPR or_else(F &&f) const & {
+    return has_value() ? *this : std::forward<F>(f)();
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \exclude
+  template <class F, detail::enable_if_ret_void<F> * = nullptr>
+  optional<T> or_else(F &&f) const && {
+    if (has_value())
+      return std::move(*this);
+
+    std::forward<F>(f)();
+    return nullopt;
+  }
+
+  /// \exclude
+  template <class F, detail::disable_if_ret_void<F> * = nullptr>
+  optional<T> or_else(F &&f) const && {
+    return has_value() ? std::move(*this) : std::forward<F>(f)();
+  }
+#endif
+
+  /// \brief Maps the stored value with `f` if there is one, otherwise returns
+  /// `u`.
+  ///
+  /// \details If there is a value stored, then `f` is called with `**this`
+  /// and the value is returned. Otherwise `u` is returned.
+  ///
+  /// \group map_or
+  template <class F, class U> U map_or(F &&f, U &&u) & {
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : std::forward<U>(u);
+  }
+
+  /// \group map_or
+  template <class F, class U> U map_or(F &&f, U &&u) && {
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : std::forward<U>(u);
+  }
+
+  /// \group map_or
+  template <class F, class U> U map_or(F &&f, U &&u) const & {
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : std::forward<U>(u);
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \group map_or
+  template <class F, class U> U map_or(F &&f, U &&u) const && {
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : std::forward<U>(u);
+  }
+#endif
+
+  /// \brief Maps the stored value with `f` if there is one, otherwise calls
+  /// `u` and returns the result.
+  ///
+  /// \details If there is a value stored, then `f` is
+  /// called with `**this` and the value is returned. Otherwise
+  /// `std::forward<U>(u)()` is returned.
+  ///
+  /// \group map_or_else
+  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u) &;
+  template <class F, class U>
+  detail::invoke_result_t<U> map_or_else(F &&f, U &&u) & {
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : std::forward<U>(u)();
+  }
+
+  /// \group map_or_else
+  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u)
+  /// &&;
+  template <class F, class U>
+  detail::invoke_result_t<U> map_or_else(F &&f, U &&u) && {
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : std::forward<U>(u)();
+  }
+
+  /// \group map_or_else
+  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u)
+  /// const &;
+  template <class F, class U>
+  detail::invoke_result_t<U> map_or_else(F &&f, U &&u) const & {
+    return has_value() ? detail::invoke(std::forward<F>(f), **this)
+                       : std::forward<U>(u)();
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \group map_or_else
+  /// \synopsis template <class F, class U>\nauto map_or_else(F &&f, U &&u)
+  /// const &&;
+  template <class F, class U>
+  detail::invoke_result_t<U> map_or_else(F &&f, U &&u) const && {
+    return has_value() ? detail::invoke(std::forward<F>(f), std::move(**this))
+                       : std::forward<U>(u)();
+  }
+#endif
+
+  /// \returns `u` if `*this` has a value, otherwise an empty optional.
+  template <class U>
+  constexpr optional<typename std::decay<U>::type> conjunction(U &&u) const {
+    using result = optional<detail::decay_t<U>>;
+    return has_value() ? result{u} : result{nullopt};
+  }
+
+  /// \returns `rhs` if `*this` is empty, otherwise the current value.
+  /// \group disjunction
+  TL_OPTIONAL_11_CONSTEXPR optional disjunction(const optional &rhs) & {
+    return has_value() ? *this : rhs;
+  }
+
+  /// \group disjunction
+  constexpr optional disjunction(const optional &rhs) const & {
+    return has_value() ? *this : rhs;
+  }
+
+  /// \group disjunction
+  TL_OPTIONAL_11_CONSTEXPR optional disjunction(const optional &rhs) && {
+    return has_value() ? std::move(*this) : rhs;
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \group disjunction
+  constexpr optional disjunction(const optional &rhs) const && {
+    return has_value() ? std::move(*this) : rhs;
+  }
+#endif
+
+  /// \group disjunction
+  TL_OPTIONAL_11_CONSTEXPR optional disjunction(optional &&rhs) & {
+    return has_value() ? *this : std::move(rhs);
+  }
+
+  /// \group disjunction
+  constexpr optional disjunction(optional &&rhs) const & {
+    return has_value() ? *this : std::move(rhs);
+  }
+
+  /// \group disjunction
+  TL_OPTIONAL_11_CONSTEXPR optional disjunction(optional &&rhs) && {
+    return has_value() ? std::move(*this) : std::move(rhs);
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \group disjunction
+  constexpr optional disjunction(optional &&rhs) const && {
+    return has_value() ? std::move(*this) : std::move(rhs);
+  }
+#endif
+
+  /// Takes the value out of the optional, leaving it empty
+  /// \group take
+  optional take() & {
+    optional ret = *this;
+    reset();
+    return ret;
+  }
+
+  /// \group take
+  optional take() const & {
+    optional ret = *this;
+    reset();
+    return ret;
+  }
+
+  /// \group take
+  optional take() && {
+    optional ret = std::move(*this);
+    reset();
+    return ret;
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \group take
+  optional take() const && {
+    optional ret = std::move(*this);
+    reset();
+    return ret;
+  }
+#endif
+
+  using value_type = T &;
+
+  /// Constructs an optional that does not contain a value.
+  /// \group ctor_empty
+  constexpr optional() noexcept : m_value(nullptr) {}
+
+  /// \group ctor_empty
+  constexpr optional(nullopt_t) noexcept : m_value(nullptr) {}
+
+  /// Copy constructor
+  ///
+  /// If `rhs` contains a value, the stored value is direct-initialized with
+  /// it. Otherwise, the constructed optional is empty.
+  TL_OPTIONAL_11_CONSTEXPR optional(const optional &rhs) noexcept = default;
+
+  /// Move constructor
+  ///
+  /// If `rhs` contains a value, the stored value is direct-initialized with
+  /// it. Otherwise, the constructed optional is empty.
+  TL_OPTIONAL_11_CONSTEXPR optional(optional &&rhs) = default;
+
+  /// Constructs the stored value with `u`.
+  /// \synopsis template <class U=T> constexpr optional(U &&u);
+  template <
+      class U = T,
+      detail::enable_if_t<std::is_convertible<U &&, T &>::value> * = nullptr,
+      detail::enable_if_t<!detail::is_optional<detail::decay_t<U>>> * = nullptr>
+  constexpr optional(U &&u) : m_value(std::addressof(u)) {}
+
+  /// \exclude
+  template <class U = T, detail::enable_if_t<
+                             !std::is_convertible<U &, T &>::value> * = nullptr>
+  constexpr optional(U &&u) : base(in_place, std::forward<U>(u)) {}
+
+  /// \exclude
+  template <class U, detail::enable_if_t<
+                         !std::is_convertible<const U &, T>::value> * = nullptr>
+  constexpr explicit optional(const optional<U> &rhs) : optional(*rhs) {}
+
+  /// No-op
+  ~optional() = default;
+
+  /// Assignment to empty.
+  ///
+  /// Destroys the current value if there is one.
+  optional &operator=(nullopt_t) noexcept {
+    m_value = nullptr;
+    return *this;
+  }
+
+  /// Copy assignment.
+  ///
+  /// Copies the value from `rhs` if there is one. Otherwise resets the stored
+  /// value in `*this`.
+  optional &operator=(const optional &rhs) = default;
+
+  /// Assigns the stored value from `u`, destroying the old value if there was
+  /// one.
+  /// \synopsis optional &operator=(U &&u);
+  template <class U = T,
+            detail::enable_if<!detail::is_optional<detail::decay_t<U>>::value>
+                * = nullptr>
+  optional &operator=(U &&u) {
+    m_value = std::addressof(u);
+    return *this;
+  }
+
+  /// Converting copy assignment operator.
+  ///
+  /// Copies the value from `rhs` if there is one. Otherwise resets the stored
+  /// value in `*this`.
+  /// \synopsis optional &operator=(const optional<U> & rhs);
+  template <class U,
+            detail::enable_if<std::is_convertible<U &, T &>::value> * = nullptr>
+  optional &operator=(const optional<U> &rhs) {
+      m_value = std::addressof(rhs.value());
+    return *this;
+  }
+
+  /// Constructs the value in-place, destroying the current one if there is
+  /// one. \group emplace
+  template <class... Args> T &emplace(Args &&... args) noexcept {
+    static_assert(std::is_constructible<T, Args &&...>::value,
+                  "T must be constructible with Args");
+
+    *this = nullopt;
+    this->construct(std::forward<Args>(args)...);
+  }
+
+  /// Swaps this optional with the other.
+  ///
+  /// If neither optionals have a value, nothing happens.
+  /// If both have a value, the values are swapped.
+  /// If one has a value, it is moved to the other and the movee is left
+  /// valueless.
+  void
+  swap(optional &rhs) noexcept {
+      std::swap(m_value, rhs.m_value);
+  }
+
+  /// \returns a pointer to the stored value
+  /// \requires a value is stored
+  /// \group pointer
+  /// \synopsis constexpr const T *operator->() const;
+  constexpr const T *operator->() const {
+    return m_value;
+  }
+
+  /// \group pointer
+  /// \synopsis constexpr T *operator->();
+  TL_OPTIONAL_11_CONSTEXPR T *operator->() {
+    return m_value;
+  }
+
+  /// \returns the stored value
+  /// \requires a value is stored
+  /// \group deref
+  /// \synopsis constexpr T &operator*();
+  TL_OPTIONAL_11_CONSTEXPR T &operator*() & { return *m_value; }
+
+  /// \group deref
+  /// \synopsis constexpr const T &operator*() const;
+  constexpr const T &operator*() const & { return *m_value; }
+
+  /// \exclude
+  TL_OPTIONAL_11_CONSTEXPR T &&operator*() && {
+    return std::move(*m_value);
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \exclude
+  constexpr const T &&operator*() const && { return std::move(*m_value); }
+#endif
+
+  /// \returns whether or not the optional has a value
+  /// \group has_value
+  constexpr bool has_value() const noexcept { return m_value != nullptr; }
+
+  /// \group has_value
+  constexpr explicit operator bool() const noexcept {
+    return m_value != nullptr;
+  }
+
+  /// \returns the contained value if there is one, otherwise throws
+  /// [bad_optional_access]
+  /// \group value
+  /// synopsis constexpr T &value();
+  TL_OPTIONAL_11_CONSTEXPR T &value() & {
+    if (has_value())
+      return *m_value;
+    throw bad_optional_access();
+  }
+  /// \group value
+  /// \synopsis constexpr const T &value() const;
+  TL_OPTIONAL_11_CONSTEXPR const T &value() const & {
+    if (has_value())
+      return *m_value;
+    throw bad_optional_access();
+  }
+  /// \exclude
+  TL_OPTIONAL_11_CONSTEXPR T &&value() && {
+    if (has_value())
+        return std::move(*m_value);
+    throw bad_optional_access();
+  }
+
+#ifndef TL_OPTIONAL_NO_CONSTRR
+  /// \exclude
+  constexpr const T &&value() const && {
+    if (has_value())
+      return std::move(*m_value);
+    throw bad_optional_access();
+  }
+#endif
+
+  /// \returns the stored value if there is one, otherwise returns `u`
+  /// \group value_or
+  template <class U> constexpr T value_or(U &&u) const & {
+    static_assert(std::is_copy_constructible<T>::value &&
+                      std::is_convertible<U &&, T>::value,
+                  "T must be copy constructible and convertible from U");
+    return has_value() ? **this : static_cast<T>(std::forward<U>(u));
+  }
+
+  /// \group value_or
+  template <class U> constexpr T value_or(U &&u) && {
+    static_assert(std::is_move_constructible<T>::value &&
+                      std::is_convertible<U &&, T>::value,
+                  "T must be move constructible and convertible from U");
+    return has_value() ? **this : static_cast<T>(std::forward<U>(u));
+  }
+
+  /// Destroys the stored value if one exists, making the optional empty
+  void reset() noexcept {
+      m_value = nullptr;
+  }
+}; // namespace tl
+
+/// \group relop
+/// \brief Compares two optional objects
+/// \details If both optionals contain a value, they are compared with `T`s
+/// relational operators. Otherwise `lhs` and `rhs` are equal only if they are
+/// both empty, and `lhs` is less than `rhs` only if `rhs` is empty and `lhs`
+/// is not.
+template <class T, class U>
+inline constexpr bool operator==(const optional<T> &lhs,
+                                 const optional<U> &rhs) {
+  return lhs.has_value() == rhs.has_value() &&
+         (!lhs.has_value() || *lhs == *rhs);
+}
+/// \group relop
+template <class T, class U>
+inline constexpr bool operator!=(const optional<T> &lhs,
+                                 const optional<U> &rhs) {
+  return lhs.has_value() != rhs.has_value() ||
+         (lhs.has_value() && *lhs != *rhs);
+}
+/// \group relop
+template <class T, class U>
+inline constexpr bool operator<(const optional<T> &lhs,
+                                const optional<U> &rhs) {
+  return rhs.has_value() && (!lhs.has_value() || *lhs < *rhs);
+}
+/// \group relop
+template <class T, class U>
+inline constexpr bool operator>(const optional<T> &lhs,
+                                const optional<U> &rhs) {
+  return lhs.has_value() && (!rhs.has_value() || *lhs > *rhs);
+}
+/// \group relop
+template <class T, class U>
+inline constexpr bool operator<=(const optional<T> &lhs,
+                                 const optional<U> &rhs) {
+  return !lhs.has_value() || (rhs.has_value() && *lhs <= *rhs);
+}
+/// \group relop
+template <class T, class U>
+inline constexpr bool operator>=(const optional<T> &lhs,
+                                 const optional<U> &rhs) {
+  return !rhs.has_value() || (lhs.has_value() && *lhs >= *rhs);
+}
+
+/// \group relop_nullopt
+/// \brief Compares an optional to a `nullopt`
+/// \details Equivalent to comparing the optional to an empty optional
+template <class T>
+inline constexpr bool operator==(const optional<T> &lhs, nullopt_t) noexcept {
+  return !lhs.has_value();
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator==(nullopt_t, const optional<T> &rhs) noexcept {
+  return !rhs.has_value();
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator!=(const optional<T> &lhs, nullopt_t) noexcept {
+  return lhs.has_value();
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator!=(nullopt_t, const optional<T> &rhs) noexcept {
+  return rhs.has_value();
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator<(const optional<T> &, nullopt_t) noexcept {
+  return false;
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator<(nullopt_t, const optional<T> &rhs) noexcept {
+  return rhs.has_value();
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator<=(const optional<T> &lhs, nullopt_t) noexcept {
+  return !lhs.has_value();
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator<=(nullopt_t, const optional<T> &) noexcept {
+  return true;
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator>(const optional<T> &lhs, nullopt_t) noexcept {
+  return lhs.has_value();
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator>(nullopt_t, const optional<T> &) noexcept {
+  return false;
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator>=(const optional<T> &, nullopt_t) noexcept {
+  return true;
+}
+/// \group relop_nullopt
+template <class T>
+inline constexpr bool operator>=(nullopt_t, const optional<T> &rhs) noexcept {
+  return !rhs.has_value();
+}
+
+/// \group relop_t
+/// \brief Compares the optional with a value.
+/// \details If the optional has a value, it is compared with the other value
+/// using `T`s relational operators. Otherwise, the optional is considered
+/// less than the value.
+template <class T, class U>
+inline constexpr bool operator==(const optional<T> &lhs, const U &rhs) {
+  return lhs.has_value() ? *lhs == rhs : false;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator==(const U &lhs, const optional<T> &rhs) {
+  return rhs.has_value() ? lhs == *rhs : false;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator!=(const optional<T> &lhs, const U &rhs) {
+  return lhs.has_value() ? *lhs != rhs : true;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator!=(const U &lhs, const optional<T> &rhs) {
+  return rhs.has_value() ? lhs != *rhs : true;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator<(const optional<T> &lhs, const U &rhs) {
+  return lhs.has_value() ? *lhs < rhs : true;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator<(const U &lhs, const optional<T> &rhs) {
+  return rhs.has_value() ? lhs < *rhs : false;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator<=(const optional<T> &lhs, const U &rhs) {
+  return lhs.has_value() ? *lhs <= rhs : true;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator<=(const U &lhs, const optional<T> &rhs) {
+  return rhs.has_value() ? lhs <= *rhs : false;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator>(const optional<T> &lhs, const U &rhs) {
+  return lhs.has_value() ? *lhs > rhs : false;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator>(const U &lhs, const optional<T> &rhs) {
+  return rhs.has_value() ? lhs > *rhs : true;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator>=(const optional<T> &lhs, const U &rhs) {
+  return lhs.has_value() ? *lhs >= rhs : false;
+}
+/// \group relop_t
+template <class T, class U>
+inline constexpr bool operator>=(const U &lhs, const optional<T> &rhs) {
+  return rhs.has_value() ? lhs >= *rhs : true;
+}
+
+/// \synopsis template <class T>\nvoid swap(optional<T> &lhs, optional<T>
+/// &rhs);
+template <class T,
+          detail::enable_if_t<std::is_move_constructible<T>::value> * = nullptr,
+          detail::enable_if_t<detail::is_swappable<T>::value> * = nullptr>
+void swap(optional<T> &lhs,
+          optional<T> &rhs) noexcept(noexcept(lhs.swap(rhs))) {
+  return lhs.swap(rhs);
+}
+
+template <class T>
+inline constexpr optional<detail::decay_t<T>> make_optional(T &&v) {
+  return optional<detail::decay_t<T>>(std::forward<T>(v));
+}
+template <class T, class... Args>
+inline constexpr optional<T> make_optional(Args &&... args) {
+  return optional<T>(in_place, std::forward<Args>(args)...);
+}
+template <class T, class U, class... Args>
+inline constexpr optional<T> make_optional(std::initializer_list<U> il,
+                                           Args &&... args) {
+  return optional<T>(in_place, il, std::forward<Args>(args)...);
+}
+
+/// \exclude
+namespace detail {
+#ifdef TL_OPTIONAL_CX14
+template <class Opt, class F,
+          class Ret = decltype(detail::invoke(std::declval<F>(),
+                                              *std::declval<Opt>())),
+          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+constexpr auto map_impl(Opt &&opt, F &&f) {
+  return opt.has_value()
+             ? detail::invoke(std::forward<F>(f), *std::forward<Opt>(opt))
+             : optional<detail::decay_t<Ret>>(nullopt);
+}
+
+template <class Opt, class F,
+          class Ret = decltype(detail::invoke(std::declval<F>(),
+                                              *std::declval<Opt>())),
+          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+auto map_impl(Opt &&opt, F &&f) {
+  if (opt.has_value()) {
+    detail::invoke(std::forward<F>(f), *std::forward<Opt>(opt));
+    return monostate{};
+  }
+
+  return optional<Ret>(nullopt);
+}
+#else
+template <class Opt, class F,
+          class Ret = decltype(detail::invoke(std::declval<F>(),
+                                              *std::declval<Opt>())),
+          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
+
+constexpr auto map_impl(Opt &&opt, F &&f) -> optional<detail::decay_t<Ret>> {
+  return opt.has_value()
+             ? detail::invoke(std::forward<F>(f), *std::forward<Opt>(opt))
+             : optional<detail::decay_t<Ret>>(nullopt);
+}
+
+template <class Opt, class F,
+          class Ret = decltype(detail::invoke(std::declval<F>(),
+                                              *std::declval<Opt>())),
+          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
+
+auto map_impl(Opt &&opt, F &&f) -> optional<monostate> {
+  if (opt.has_value()) {
+    detail::invoke(std::forward<F>(f), *std::forward<Opt>(opt));
+    return monostate{};
+  }
+
+  return nullopt;
+}
+#endif
+} // namespace detail
 
 } // namespace tl
 

--- a/tl/optional.hpp
+++ b/tl/optional.hpp
@@ -697,11 +697,11 @@ public:
   /// \group and_then
   /// Carries out some operation which returns an optional on the stored
   /// object if there is one. \requires `std::invoke(std::forward<F>(f),
-  /// value())` returns a `std::optional<U>` for some `U`. \returns Let `U` be
-  /// the result of `std::invoke(std::forward<F>(f), value())`. Returns a
-  /// `std::optional<U>`. The return value is empty if `*this` is empty,
-  /// otherwise the return value of `std::invoke(std::forward<F>(f), value())`
-  /// is returned.
+  /// value())` returns a `std::optional<U>` for some `U`.
+  /// \returns Let `U` be the result of `std::invoke(std::forward<F>(f),
+  /// value())`. Returns a `std::optional<U>`. The return value is empty if
+  /// `*this` is empty, otherwise the return value of
+  /// `std::invoke(std::forward<F>(f), value())` is returned.
   /// \group and_then
   /// \synopsis template <class F>\nconstexpr auto and_then(F &&f) &;
   template <class F>
@@ -834,7 +834,8 @@ public:
 
   /// \brief Calls `f` if the optional is empty
   /// \requires `std::invoke_result_t<F>` must be void or convertible to
-  /// `optional<T>`. \effects If `*this` has a value, returns `*this`.
+  /// `optional<T>`.
+  /// \effects If `*this` has a value, returns `*this`.
   /// Otherwise, if `f` returns `void`, calls `std::forward<F>(f)` and returns
   /// `std::nullopt`. Otherwise, returns `std::forward<F>(f)()`.
   ///
@@ -1089,8 +1090,7 @@ public:
 
   /// Constructs the stored value in-place using the given arguments.
   /// \group in_place
-  /// \synopsis template <class... Args> constexpr explicit
-  /// optional(in_place_t, Args&&... args);
+  /// \synopsis template <class... Args> constexpr explicit optional(in_place_t, Args&&... args);
   template <class... Args>
   constexpr explicit optional(
       detail::enable_if_t<std::is_constructible<T, Args...>::value, in_place_t>,
@@ -1098,8 +1098,7 @@ public:
       : base(in_place, std::forward<Args>(args)...) {}
 
   /// \group in_place
-  /// \synopsis template <class U, class... Args>\nconstexpr explicit
-  /// optional(in_place_t, std::initializer_list<U>&, Args&&... args);
+  /// \synopsis template <class U, class... Args>\nconstexpr explicit optional(in_place_t, std::initializer_list<U>&, Args&&... args);
   template <class U, class... Args>
   TL_OPTIONAL_11_CONSTEXPR explicit optional(
       detail::enable_if_t<std::is_constructible<T, std::initializer_list<U> &,
@@ -1246,7 +1245,8 @@ public:
   }
 
   /// Constructs the value in-place, destroying the current one if there is
-  /// one. \group emplace
+  /// one.
+  /// \group emplace
   template <class... Args> T &emplace(Args &&... args) {
     static_assert(std::is_constructible<T, Args &&...>::value,
                   "T must be constructible with Args");
@@ -1256,8 +1256,7 @@ public:
   }
 
   /// \group emplace
-  /// \synopsis template <class U, class... Args>\nT&
-  /// emplace(std::initializer_list<U> il, Args &&... args);
+  /// \synopsis template <class U, class... Args>\nT& emplace(std::initializer_list<U> il, Args &&... args);
   template <class U, class... Args>
   detail::enable_if_t<
       std::is_constructible<T, std::initializer_list<U> &, Args &&...>::value,
@@ -1336,7 +1335,7 @@ public:
   /// \returns the contained value if there is one, otherwise throws
   /// [bad_optional_access]
   /// \group value
-  /// synopsis constexpr T &value();
+  /// \synopsis constexpr T &value();
   TL_OPTIONAL_11_CONSTEXPR T &value() & {
     if (has_value())
       return this->m_value;
@@ -1563,8 +1562,7 @@ inline constexpr bool operator>=(const U &lhs, const optional<T> &rhs) {
   return rhs.has_value() ? lhs >= *rhs : true;
 }
 
-/// \synopsis template <class T>\nvoid swap(optional<T> &lhs, optional<T>
-/// &rhs);
+/// \synopsis template <class T>\nvoid swap(optional<T> &lhs, optional<T> &rhs);
 template <class T,
           detail::enable_if_t<std::is_move_constructible<T>::value> * = nullptr,
           detail::enable_if_t<detail::is_swappable<T>::value> * = nullptr>
@@ -1599,12 +1597,28 @@ inline constexpr optional<T> make_optional(std::initializer_list<U> il,
 template <class T> optional(T)->optional<T>;
 #endif
 
-/// An optional object is an object that contains the storage for another
-/// object and manages the lifetime of this contained object, if any. The
-/// contained object may be initialized after the optional object has been
-/// initialized, and may be destroyed before the optional object has been
-/// destroyed. The initialization state of the contained object is tracked by
-/// the optional object.
+/// Specialization for when `T` is a reference. `optional<T&>` acts similarly
+/// to a `T*`, but provides more operations and shows intent more clearly.
+///
+/// *Examples*:
+///
+/// ```
+/// int i = 42;
+/// tl::optional<int&> o = i;
+/// *o == 42; //true
+/// i = 12;
+/// *o = 12; //true
+/// &*o == &i; //true
+/// ```
+///
+/// Assignment has rebind semantics rather than assign-through semantics:
+///
+/// ```
+/// int j = 8;
+/// o = j;
+///
+/// &*o == &j; //true
+/// ```
 template <class T> class optional<T &> {
 public:
 // The different versions for C++14 and 11 are needed because deduced return
@@ -2062,10 +2076,9 @@ public:
 
   /// Constructs the stored value with `u`.
   /// \synopsis template <class U=T> constexpr optional(U &&u);
-  template <
-      class U = T,
-      detail::enable_if_t<!detail::is_optional<detail::decay_t<U>>::value> * =
-          nullptr>
+  template <class U = T,
+            detail::enable_if_t<!detail::is_optional<detail::decay_t<U>>::value>
+                * = nullptr>
   constexpr optional(U &&u) : m_value(std::addressof(u)) {
     static_assert(std::is_lvalue_reference<U>::value, "U must be an lvalue");
   }
@@ -2087,12 +2100,13 @@ public:
 
   /// Copy assignment.
   ///
-  /// Copies the value from `rhs` if there is one. Otherwise resets the stored
-  /// value in `*this`.
+  /// Rebinds this optional to the referee of `rhs` if there is one. Otherwise
+  /// resets the stored value in `*this`.
   optional &operator=(const optional &rhs) = default;
 
-  /// Assigns the stored value from `u`, destroying the old value if there was
-  /// one.
+  /// Rebinds this optional to `u`.
+  ///
+  /// \requires `U` must be an lvalue reference.
   /// \synopsis optional &operator=(U &&u);
   template <class U = T,
             detail::enable_if_t<!detail::is_optional<detail::decay_t<U>>::value>
@@ -2105,17 +2119,17 @@ public:
 
   /// Converting copy assignment operator.
   ///
-  /// Copies the value from `rhs` if there is one. Otherwise resets the stored
-  /// value in `*this`.
-  /// \synopsis optional &operator=(const optional<U> & rhs);
-  template <class U>
-  optional &operator=(const optional<U> &rhs) {
+  /// Rebinds this optional to the referee of `rhs` if there is one. Otherwise
+  /// resets the stored value in `*this`.
+  template <class U> optional &operator=(const optional<U> &rhs) {
     m_value = std::addressof(rhs.value());
     return *this;
   }
 
   /// Constructs the value in-place, destroying the current one if there is
-  /// one. \group emplace
+  /// one.
+  ///
+  /// \group emplace
   template <class... Args> T &emplace(Args &&... args) noexcept {
     static_assert(std::is_constructible<T, Args &&...>::value,
                   "T must be constructible with Args");


### PR DESCRIPTION
`tl::optional` now supports references:

```
int i = 42;
tl::optional<int&> o = i;
*o == 42; //true
i = 12;
*o = 12; //true
&*o == &i; //true
```

Assignment has rebind semantics:

```
int j = 8;
o = j;

&*o == &j; //true
```