### PR TITLE
Add return

### DIFF
--- a/tl/optional.hpp
+++ b/tl/optional.hpp
@@ -372,7 +372,7 @@ template <class T> struct optional_operations_base : optional_storage_base<T> {
 
   TL_OPTIONAL_11_CONSTEXPR T &get() & { return this->m_value; }
   TL_OPTIONAL_11_CONSTEXPR const T &get() const & { return this->m_value; }
-  TL_OPTIONAL_11_CONSTEXPR T &&get() && { std::move(this->m_value); }
+  TL_OPTIONAL_11_CONSTEXPR T &&get() && { return std::move(this->m_value); }
 #ifndef TL_OPTIONAL_NO_CONSTRR
   constexpr const T &&get() const && { return std::move(this->m_value); }
 #endif


### PR DESCRIPTION
clang 5.0 complains about missing `return` statement:

```
/home/b/development/android/projects/beetris/proj.cmake/../lib/tl/optional.hpp:376:69: warning: control reaches end of non-void function [-Wreturn-type]
  TL_OPTIONAL_11_CONSTEXPR T &&get() && { std::move(this->m_value); }
                                                                    ^
/home/b/development/android/projects/beetris/proj.cmake/../lib/tl/optional.hpp:360:48: note: in instantiation of member function 'tl::detail::optional_operations_base<TestCell>::get'
      requested here
        this->m_value = std::forward<Opt>(rhs).get();
                                               ^
/home/b/development/android/projects/beetris/proj.cmake/../lib/tl/optional.hpp:495:11: note: in instantiation of function template specialization
      'tl::detail::optional_operations_base<TestCell>::assign<tl::detail::optional_move_assign_base<TestCell, false> >' requested here
    this->assign(std::move(rhs));
          ^
/home/b/development/android/projects/beetris/proj.cmake/../lib/tl/optional.hpp:1186:47: note: in instantiation of member function 'tl::detail::optional_move_assign_base<TestCell,
      false>::operator=' requested here
  optional &operator=(optional &&rhs) = default;
```

The PR fixes that issue.