### PR TITLE
Added tests for bug when swapping value/null-value and null-value value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,8 @@ if(OPTIONAL_ENABLE_TESTS)
                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/assignment.cpp
                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/issues.cpp  
                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/bases.cpp
-                   ${CMAKE_CURRENT_SOURCE_DIR}/tests/nullopt.cpp)
+                   ${CMAKE_CURRENT_SOURCE_DIR}/tests/nullopt.cpp
+                   ${CMAKE_CURRENT_SOURCE_DIR}/tests/swap.cpp)
 
   add_executable(tests ${TEST_SOURCES})
 

--- a/tests/swap.cpp
+++ b/tests/swap.cpp
@@ -1,0 +1,26 @@
+#include "catch.hpp"
+#include "optional.hpp"
+
+TEST_CASE("Swap value", "[swap.value]") {
+  tl::optional<int> o1 = 42;
+  tl::optional<int> o2 = 12;
+  o1.swap(o2);
+  CHECK(o1.value() == 12);
+  CHECK(o2.value() == 42);
+}
+
+TEST_CASE("Swap value with null intialized", "[swap.value_nullopt]") {
+  tl::optional<int> o1 = 42;
+  tl::optional<int> o2 = tl::nullopt;
+  o1.swap(o2);
+  CHECK(!o1.has_value());
+  CHECK(o2.value() == 42);
+}
+
+TEST_CASE("Swap null intialized with value", "[swap.nullopt_value]") {
+  tl::optional<int> o1 = tl::nullopt;
+  tl::optional<int> o2 = 42;
+  o1.swap(o2);
+  CHECK(o1.value() == 42);
+  CHECK(!o2.has_value());
+}

--- a/tl/optional.hpp
+++ b/tl/optional.hpp
@@ -1238,9 +1238,9 @@ public:
   void
   swap(optional &rhs) noexcept(std::is_nothrow_move_constructible<T>::value
                                    &&detail::is_nothrow_swappable<T>::value) {
+    using std::swap;
     if (has_value()) {
       if (rhs.has_value()) {
-        using std::swap;
         swap(**this, *rhs);
       } else {
         new (std::addressof(rhs.m_value)) T(std::move(this->m_value));
@@ -1250,6 +1250,7 @@ public:
       new (std::addressof(this->m_value)) T(std::move(rhs.m_value));
       rhs.m_value.T::~T();
     }
+    swap(this->m_has_value, rhs.m_has_value);
   }
 
   /// Returns a pointer to the stored value


### PR DESCRIPTION
The swap function behaviour isn't correct when one of the optional objects that don't contain a value