### PR TITLE
Fix various compile warnings

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,6 @@ build_script:
   - git submodule update --init --recursive
   - mkdir build
   - cd build
-  - cmake ..
+  - cmake -DOPTIONAL_WERROR=ON ..
   - cmake --build .
   - C:\projects\optional\build\Debug\tests.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -254,4 +254,4 @@ install:
     - if [ "$CXX" = "clang++" ]; then export CXX="$COMPILER -stdlib=libc++"; fi
     - if [ "$CXX" = "g++" ]; then export CXX="$COMPILER"; fi
 
-script: mkdir build && cd build && cmake -DCXXSTD=$CXXSTD .. && make && ./tests
+script: mkdir build && cd build && cmake -DCXXSTD=$CXXSTD -DOPTIONAL_WERROR=ON .. && make && ./tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,14 @@ matrix:
           sources:
              - ubuntu-toolchain-r-test
           packages:
+             - g++-9
+      env: COMPILER=g++-9 CXXSTD=11
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+             - ubuntu-toolchain-r-test
+          packages:
              - g++-4.9
       env: COMPILER=g++-4.9 CXXSTD=11
     - compiler: gcc
@@ -168,6 +176,14 @@ matrix:
           packages:
              - g++-8
       env: COMPILER=g++-8 CXXSTD=14
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+             - ubuntu-toolchain-r-test
+          packages:
+             - g++-9
+      env: COMPILER=g++-9 CXXSTD=14
     - compiler: clang
       addons:
         apt:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.11)
 project(tl-optional VERSION 1.0.0 LANGUAGES CXX)
 
 option(OPTIONAL_ENABLE_TESTS "Enable tests." ON)
+option(OPTIONAL_WERROR "Turn compiler warnings into errors" OFF)
 
 include(FetchContent)
 FetchContent_Declare(
@@ -16,7 +17,7 @@ if(NOT tl_cmake_POPULATED)
 endif()
 include(add-tl)
 
-tl_add_library(optional SOURCES 
+tl_add_library(optional SOURCES
                 include/tl/optional.hpp)
 
 if(OPTIONAL_ENABLE_TESTS)
@@ -37,7 +38,7 @@ if(OPTIONAL_ENABLE_TESTS)
                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/constexpr.cpp
                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/constructors.cpp
                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/assignment.cpp
-                   ${CMAKE_CURRENT_SOURCE_DIR}/tests/issues.cpp  
+                   ${CMAKE_CURRENT_SOURCE_DIR}/tests/issues.cpp
                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/bases.cpp
                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/nullopt.cpp
                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/swap.cpp)
@@ -50,3 +51,10 @@ if(OPTIONAL_ENABLE_TESTS)
   set_property(TARGET tests PROPERTY CXX_STANDARD ${CXXSTD})
 endif()
 
+if(OPTIONAL_WERROR)
+  if(MSVC)
+    target_compile_options(optional INTERFACE /W3 /WX)
+  else()
+    target_compile_options(optional INTERFACE -Wall -Wextra -pedantic -Werror)
+  endif()
+endif()

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Tested on:
   * clang 3.7
   * clang 3.6
   * clang 3.5
+  * g++ 9.1.0
   * g++ 8.0.1
   * g++ 7.3
   * g++ 6.4

--- a/include/tl/optional.hpp
+++ b/include/tl/optional.hpp
@@ -452,7 +452,8 @@ struct optional_copy_base<T, false> : optional_operations_base<T> {
   using optional_operations_base<T>::optional_operations_base;
 
   optional_copy_base() = default;
-  optional_copy_base(const optional_copy_base &rhs) {
+  optional_copy_base(const optional_copy_base &rhs)
+      : optional_operations_base<T>() {
     if (rhs.has_value()) {
       this->construct(rhs.get());
     } else {

--- a/tests/extensions.cpp
+++ b/tests/extensions.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Monadic operations", "[monadic]") {
 
     // test void return
     tl::optional<int> o7 = 40;
-    auto f7 = [](const int &i) { return; };
+    auto f7 = [](const int&) { return; };
     auto o7r = o7.map(f7);
     STATIC_REQUIRE(
         (std::is_same<decltype(o7r), tl::optional<tl::monostate>>::value));
@@ -188,7 +188,7 @@ TEST_CASE("Monadic operations", "[monadic]") {
 
     // test void return
     tl::optional<int> o7 = 40;
-    auto f7 = [](const int& i) { return; };
+    auto f7 = [](const int&) { return; };
     auto o7r = o7.transform(f7);
     STATIC_REQUIRE(
       (std::is_same<decltype(o7r), tl::optional<tl::monostate>>::value));
@@ -295,25 +295,25 @@ TEST_CASE("Monadic operations", "[monadic]") {
 
     // lhs is empty
     tl::optional<int> o1;
-    auto o1r = o1.and_then([](int i) { return tl::optional<float>{42}; });
+    auto o1r = o1.and_then([](int) { return tl::optional<float>{42.f}; });
     STATIC_REQUIRE((std::is_same<decltype(o1r), tl::optional<float>>::value));
     REQUIRE(!o1r);
 
     // lhs has value
     tl::optional<int> o2 = 12;
-    auto o2r = o2.and_then([](int i) { return tl::optional<float>{42}; });
+    auto o2r = o2.and_then([](int) { return tl::optional<float>{42.f}; });
     STATIC_REQUIRE((std::is_same<decltype(o2r), tl::optional<float>>::value));
     REQUIRE(o2r.value() == 42.f);
 
     // lhs is empty, rhs returns empty
     tl::optional<int> o3;
-    auto o3r = o3.and_then([](int i) { return tl::optional<float>{}; });
+    auto o3r = o3.and_then([](int) { return tl::optional<float>{}; });
     STATIC_REQUIRE((std::is_same<decltype(o3r), tl::optional<float>>::value));
     REQUIRE(!o3r);
 
     // rhs returns empty
     tl::optional<int> o4 = 12;
-    auto o4r = o4.and_then([](int i) { return tl::optional<float>{}; });
+    auto o4r = o4.and_then([](int) { return tl::optional<float>{}; });
     STATIC_REQUIRE((std::is_same<decltype(o4r), tl::optional<float>>::value));
     REQUIRE(!o4r);
 
@@ -345,38 +345,38 @@ TEST_CASE("Monadic operations", "[monadic]") {
 
     // test each overload in turn
     tl::optional<int> o8 = 42;
-    auto o8r = o8.and_then([](int i) { return tl::make_optional(42); });
+    auto o8r = o8.and_then([](int) { return tl::make_optional(42); });
     REQUIRE(*o8r == 42);
 
     tl::optional<int> o9 = 42;
     auto o9r =
-        std::move(o9).and_then([](int i) { return tl::make_optional(42); });
+        std::move(o9).and_then([](int) { return tl::make_optional(42); });
     REQUIRE(*o9r == 42);
 
     const tl::optional<int> o10 = 42;
-    auto o10r = o10.and_then([](int i) { return tl::make_optional(42); });
+    auto o10r = o10.and_then([](int) { return tl::make_optional(42); });
     REQUIRE(*o10r == 42);
 
     const tl::optional<int> o11 = 42;
     auto o11r =
-        std::move(o11).and_then([](int i) { return tl::make_optional(42); });
+        std::move(o11).and_then([](int) { return tl::make_optional(42); });
     REQUIRE(*o11r == 42);
 
     tl::optional<int> o16 = tl::nullopt;
-    auto o16r = o16.and_then([](int i) { return tl::make_optional(42); });
+    auto o16r = o16.and_then([](int) { return tl::make_optional(42); });
     REQUIRE(!o16r);
 
     tl::optional<int> o17 = tl::nullopt;
     auto o17r =
-        std::move(o17).and_then([](int i) { return tl::make_optional(42); });
+        std::move(o17).and_then([](int) { return tl::make_optional(42); });
     REQUIRE(!o17r);
 
     const tl::optional<int> o18 = tl::nullopt;
-    auto o18r = o18.and_then([](int i) { return tl::make_optional(42); });
+    auto o18r = o18.and_then([](int) { return tl::make_optional(42); });
     REQUIRE(!o18r);
 
     const tl::optional<int> o19 = tl::nullopt;
-    auto o19r = std::move(o19).and_then([](int i) { return tl::make_optional(42); });
+    auto o19r = std::move(o19).and_then([](int) { return tl::make_optional(42); });
     REQUIRE(!o19r);
 
     int i = 3;
@@ -487,5 +487,6 @@ TEST_CASE("Monadic operations", "[monadic]") {
   SECTION("Issue #2") {
     tl::optional<foo> f = foo{};
     auto x = f.and_then(overloaded{});
+    (void)x;
   }
-};
+}

--- a/tests/issues.cpp
+++ b/tests/issues.cpp
@@ -24,6 +24,7 @@ struct fail_on_copy_self {
     fail_on_copy_self(const fail_on_copy_self& other) : value(other.value) {
         REQUIRE(&other != this);
     }
+    fail_on_copy_self& operator=(const fail_on_copy_self&) = default;
 };
 
 TEST_CASE("issue 15") {


### PR DESCRIPTION
This fixes some compile warnings. To avoid introducing new warnings by accident, I added the option `OPTIONAL_WERROR` to the CMake config which allows to compile with the flags `-Werror`, `-Wall`, `-Wextra` and `-pedantic`. This option is disabled by default (to avoid errors when using for example a more recent compiler), but enabled on CI to make CI fail on warnings.

In addition, I added new CI jobs for GCC 9.x to increase compiler coverage.

Please let me know if I should change something. Especially with CMake I have no experience at all.