### PR TITLE
hash<> SFINAE protection

### DIFF
--- a/tests/hash.cpp
+++ b/tests/hash.cpp
@@ -1,4 +1,30 @@
 #include "catch.hpp"
 #include <tl/optional.hpp>
 
-TEST_CASE("Hashing", "[hash]") {}
+template <typename T, typename = tl::detail::void_t<>>
+struct is_hashable : std::false_type {};
+
+template <typename T>
+struct is_hashable<T, tl::detail::void_t<decltype(std::declval<std::hash<T>>()(
+                          std::declval<T>()))>> : std::true_type {};
+
+template <typename T> constexpr bool is_hashable_v = is_hashable<T>::value;
+
+struct not_hashable {};
+
+TEST_CASE("Hashing", "[hash]") {
+  SECTION("with value") {
+    tl::optional<int> op1(1);
+
+    static_assert(is_hashable_v<tl::optional<int>>,
+                  "tl::optional<int> should be hashable");
+    static_assert(!is_hashable_v<tl::optional<not_hashable>>,
+                  "tl::optional<not_hashable> should not be hashable");
+
+    REQUIRE(std::hash<int>{}(1) == std::hash<tl::optional<int>>{}(op1));
+  }
+  SECTION("nullopt") {
+    tl::optional<int> op1(tl::nullopt);
+    REQUIRE(std::hash<tl::optional<int>>{}(op1) == 0);
+  }
+}


### PR DESCRIPTION
I saw that under the hash specialization of tl::optional, there was a TODO for a SFINAE guard. The guard I implemented is based off of libc++'s but unlike their implementation, mine works for C++11.