### PR TITLE
Add library.json for platformio

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,13 @@
+{
+    "name": "optional",
+    "version": "1.0.0",
+    "build": {
+        "includeDir": "include",
+        "srcFilter": [
+            "+<*>",
+            "-<.git>",
+            "-<cmake/>",
+            "-<tests/*>"
+        ]
+    }
+}


### PR DESCRIPTION
To get the library working on the ESP32 microcontroller with platformio, you need to have this json file inside the lib repo.

To use this lib in platformio, add the dependency in your .ini file as shown below:

```
[env:project1]
lib_deps =
    https://github.com/0xFEEDC0DE64/optional.git
```