### PR TITLE
Added explicit default initialization in copy constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 \#*
 .\#*
 /build/
+.idea
+cmake-*

--- a/include/tl/optional.hpp
+++ b/include/tl/optional.hpp
@@ -453,7 +453,7 @@ struct optional_copy_base<T, false> : optional_operations_base<T> {
 
   optional_copy_base() = default;
   optional_copy_base(const optional_copy_base &rhs)
-  : optional_copy_base() {
+  : optional_operations_base<T>() {
     if (rhs.has_value()) {
       this->construct(rhs.get());
     } else {

--- a/include/tl/optional.hpp
+++ b/include/tl/optional.hpp
@@ -448,21 +448,30 @@ struct optional_copy_base : optional_operations_base<T> {
 
 // This specialization is for when T is not trivially copy constructible
 template <class T>
-struct optional_copy_base<T, false> : optional_operations_base<T> {
-  using optional_operations_base<T>::optional_operations_base;
+struct optional_copy_base<T, false> : optional_operations_base<T>
+{
+    using optional_operations_base<T>::optional_operations_base;
 
-  optional_copy_base() = default;
-  optional_copy_base(const optional_copy_base &rhs) {
-    if (rhs.has_value()) {
-      this->construct(rhs.get());
-    } else {
-      this->m_has_value = false;
+    optional_copy_base() = default;
+
+    optional_copy_base(const optional_copy_base &rhs)
+            : optional_copy_base()
+    {
+        if (rhs.has_value())
+        {
+            this->construct(rhs.get());
+        }
+        else
+        {
+            this->m_has_value = false;
+        }
     }
-  }
 
-  optional_copy_base(optional_copy_base &&rhs) = default;
-  optional_copy_base &operator=(const optional_copy_base &rhs) = default;
-  optional_copy_base &operator=(optional_copy_base &&rhs) = default;
+    optional_copy_base(optional_copy_base &&rhs) = default;
+
+    optional_copy_base &operator=(const optional_copy_base &rhs) = default;
+
+    optional_copy_base &operator=(optional_copy_base &&rhs) = default;
 };
 
 // This class manages conditionally having a trivial move constructor

--- a/include/tl/optional.hpp
+++ b/include/tl/optional.hpp
@@ -448,30 +448,22 @@ struct optional_copy_base : optional_operations_base<T> {
 
 // This specialization is for when T is not trivially copy constructible
 template <class T>
-struct optional_copy_base<T, false> : optional_operations_base<T>
-{
-    using optional_operations_base<T>::optional_operations_base;
+struct optional_copy_base<T, false> : optional_operations_base<T> {
+  using optional_operations_base<T>::optional_operations_base;
 
-    optional_copy_base() = default;
-
-    optional_copy_base(const optional_copy_base &rhs)
-            : optional_copy_base()
-    {
-        if (rhs.has_value())
-        {
-            this->construct(rhs.get());
-        }
-        else
-        {
-            this->m_has_value = false;
-        }
+  optional_copy_base() = default;
+  optional_copy_base(const optional_copy_base &rhs)
+  : optional_copy_base() {
+    if (rhs.has_value()) {
+      this->construct(rhs.get());
+    } else {
+      this->m_has_value = false;
     }
+  }
 
-    optional_copy_base(optional_copy_base &&rhs) = default;
-
-    optional_copy_base &operator=(const optional_copy_base &rhs) = default;
-
-    optional_copy_base &operator=(optional_copy_base &&rhs) = default;
+  optional_copy_base(optional_copy_base &&rhs) = default;
+  optional_copy_base &operator=(const optional_copy_base &rhs) = default;
+  optional_copy_base &operator=(optional_copy_base &&rhs) = default;
 };
 
 // This class manages conditionally having a trivial move constructor


### PR DESCRIPTION
Copy constructor produces warnings, thus failing the build with `-Werror=all`. Added explicit initialization.

```
../3rdparty/optional/include/tl/optional.hpp:455:3: error: base class 'struct tl::detail::optional_operations_base<std::__cxx11::basic_string<char> >' should be explicitly initialized in the copy constructor [-Werror=extra]
  455 |   optional_copy_base(const optional_copy_base &rhs) {
      |   ^~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```