### PR TITLE
Remove `noexcept` specifier for `construct()`

### DIFF
--- a/include/tl/optional.hpp
+++ b/include/tl/optional.hpp
@@ -409,7 +409,7 @@ template <class T> struct optional_operations_base : optional_storage_base<T> {
     this->m_has_value = false;
   }
 
-  template <class... Args> void construct(Args &&... args) noexcept {
+  template <class... Args> void construct(Args &&... args) {
     new (std::addressof(this->m_value)) T(std::forward<Args>(args)...);
     this->m_has_value = true;
   }

--- a/tests/emplace.cpp
+++ b/tests/emplace.cpp
@@ -11,3 +11,14 @@ TEST_CASE("Emplace", "[emplace]") {
     REQUIRE(i->second.first == 3);
     REQUIRE(i->second.second == 4);    
 }
+
+struct A {
+    A() {
+        throw std::exception();
+    }
+};
+
+TEST_CASE("Emplace with exception thrown", "[emplace]") {
+    tl::optional<A> a;
+    REQUIRE_THROWS(a.emplace());
+}


### PR DESCRIPTION
In case of calling `emplace()`, if constructor throws exception, application calls `terminate()` and it is not catched