### PR TITLE
Update Catch2 dependency to latest release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,42 +74,18 @@ if (OPTIONAL_BUILD_TESTS)
   set(CATCH_BUILD_TESTING OFF)
   set(CATCH_INSTALL_DOCS OFF)
   FetchContent_Declare(Catch2 URL
-    https://github.com/catchorg/Catch2/archive/v2.9.2.zip) 
+    https://github.com/catchorg/Catch2/archive/v3.6.0.zip) 
   FetchContent_MakeAvailable(Catch2)
-
-  file(GENERATE OUTPUT catch.main.cpp
-    CONTENT [[
-      #define CATCH_CONFIG_MAIN
-      #include <catch2/catch.hpp>
-  ]])
-  set_property(SOURCE ${PROJECT_BINARY_DIR}/catch.main.cpp
-    PROPERTY
-      GENERATED ON)
-  add_library(${PROJECT_NAME}-catch-main OBJECT)
-  target_sources(${PROJECT_NAME}-catch-main PRIVATE
-    ${PROJECT_BINARY_DIR}/catch.main.cpp)
-  target_compile_options(${PROJECT_NAME}-catch-main
-    PUBLIC
-      $<$<AND:$<CXX_COMPILER_ID:Clang>,$<BOOL:"$ENV{TRAVIS}">>:-stdlib=libc++>
-      $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra>)
-  target_link_options(${PROJECT_NAME}-catch-main
-    PUBLIC
-      $<$<AND:$<CXX_COMPILER_ID:Clang>,$<BOOL:"$ENV{TRAVIS}">>:-stdlib=libc++>)
-  target_link_libraries(${PROJECT_NAME}-catch-main
-    PUBLIC
-      Catch2::Catch2
-      optional)
 
   file(GLOB test-sources CONFIGURE_DEPENDS tests/*.cpp)
   foreach (source IN LISTS test-sources)
     get_filename_component(name "${source}" NAME_WE)
     set(test "${PROJECT_NAME}-test-${name}")
     add_executable(${test}
-      "${source}"
-      $<TARGET_OBJECTS:${PROJECT_NAME}-catch-main>)
+      "${source}")
     target_link_libraries(${test}
       PRIVATE
-        ${PROJECT_NAME}-catch-main)
+        Catch2::Catch2WithMain optional)
     add_test(NAME ${PROJECT_NAME}::test::${name} COMMAND ${test})
   endforeach()
 endif()

--- a/tests/assignment.cpp
+++ b/tests/assignment.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/optional.hpp>
 
 TEST_CASE("Assignment value", "[assignment.value]") {

--- a/tests/bases.cpp
+++ b/tests/bases.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/optional.hpp>
 
 // Old versions of GCC don't have the correct trait names. Could fix them up if needs be.

--- a/tests/constexpr.cpp
+++ b/tests/constexpr.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/optional.hpp>
 
 TEST_CASE("Constexpr", "[constexpr]") {

--- a/tests/constructors.cpp
+++ b/tests/constructors.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/optional.hpp>
 #include <vector>
 

--- a/tests/emplace.cpp
+++ b/tests/emplace.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/optional.hpp>
 #include <utility>
 #include <tuple>

--- a/tests/extensions.cpp
+++ b/tests/extensions.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/optional.hpp>
 #include <string>
 

--- a/tests/hash.cpp
+++ b/tests/hash.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/optional.hpp>
 
 TEST_CASE("Hashing", "[hash]") {}

--- a/tests/in_place.cpp
+++ b/tests/in_place.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/optional.hpp>
 
 #include <tuple>

--- a/tests/issues.cpp
+++ b/tests/issues.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/optional.hpp>
 #include <type_traits>
 

--- a/tests/make_optional.cpp
+++ b/tests/make_optional.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/optional.hpp>
 
 #include <tuple>

--- a/tests/noexcept.cpp
+++ b/tests/noexcept.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/optional.hpp>
 
 TEST_CASE("Noexcept", "[noexcept]") {

--- a/tests/nullopt.cpp
+++ b/tests/nullopt.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/optional.hpp>
 
 TEST_CASE("Nullopt", "[nullopt]") {

--- a/tests/observers.cpp
+++ b/tests/observers.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/optional.hpp>
 
 struct move_detector {

--- a/tests/relops.cpp
+++ b/tests/relops.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/optional.hpp>
 
 TEST_CASE("Relational ops", "[relops]") {

--- a/tests/swap.cpp
+++ b/tests/swap.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <tl/optional.hpp>
 
 TEST_CASE("Swap value", "[swap.value]") {


### PR DESCRIPTION
This simplifies the required setup code for the test suite and makes it easier to package for Linux distributions such as Debian.