### PR TITLE
Add `begin`/`end`

### DIFF
--- a/include/tl/optional.hpp
+++ b/include/tl/optional.hpp
@@ -1256,6 +1256,24 @@ public:
     swap(this->m_has_value, rhs.m_has_value);
   }
 
+  using iterator = T *;
+  using const_iterator = const T *;
+
+  /// Returns an iterator to the stored value, otherwise returns a past-the-end
+  /// iterator
+  constexpr iterator begin() noexcept {
+    return std::addressof(this->m_value) + !has_value();
+  }
+  constexpr iterator end() noexcept {
+    return std::addressof(this->m_value) + 1;
+  }
+  constexpr const_iterator begin() const noexcept {
+    return std::addressof(this->m_value) + !has_value();
+  }
+  constexpr const_iterator end() const noexcept {
+    return std::addressof(this->m_value) + 1;
+  }
+
   /// Returns a pointer to the stored value
   constexpr const T *operator->() const {
     return std::addressof(this->m_value);
@@ -1991,6 +2009,18 @@ public:
   }
 
   void swap(optional &rhs) noexcept { std::swap(m_value, rhs.m_value); }
+
+  using iterator = T *;
+  using const_iterator = const T *;
+
+  /// Returns an iterator to the stored value, otherwise returns a past-the-end
+  /// iterator
+  constexpr iterator begin() noexcept { return m_value + !has_value(); }
+  constexpr iterator end() noexcept { return m_value + 1; }
+  constexpr const_iterator begin() const noexcept {
+    return m_value + !has_value();
+  }
+  constexpr const_iterator end() const noexcept { return m_value + 1; }
 
   /// Returns a pointer to the stored value
   constexpr const T *operator->() const noexcept { return m_value; }

--- a/tests/iterator.cpp
+++ b/tests/iterator.cpp
@@ -1,0 +1,22 @@
+#include <catch2/catch.hpp>
+#include <tl/optional.hpp>
+
+TEST_CASE("iterator reference", "[iterator.ref]") {
+  int val = 3;
+
+  tl::optional<int &> o = val;
+  REQUIRE(o.begin() != o.end());
+  REQUIRE(*o.begin() == 3);
+
+  o = tl::nullopt;
+  REQUIRE(o.begin() == o.end());
+}
+
+TEST_CASE("iterator value constexpr", "[iterator.value.constexpr]") {
+  constexpr tl::optional<int> empty;
+  STATIC_REQUIRE(empty.begin() == empty.end());
+
+  constexpr tl::optional<int> value = 3;
+  STATIC_REQUIRE(value.begin() != value.end());
+  STATIC_REQUIRE(*value.begin() == 3);
+}


### PR DESCRIPTION
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3168r2.html

The paper also adds following template specializations, but I don't have any idea on how to implement them without `__has_include` which is available only since C++17
```cpp
template<class T>
constexpr bool ranges::enable_view<optional<T>> = true;   
template<class T>
constexpr auto format_kind<optional<T>> = range_format::disabled;
```